### PR TITLE
Feat/loginpage design

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -147,7 +147,7 @@ export default function App() {
         'NotoSansCJKkr-Regular': require('@assets/fonts/NotoSansCJKkr-Regular.otf'),
     });
 
-    const [isLoggedIn, setIsLoggedIn] = useState(true);
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
 
     if (!loaded) {
         return null;

--- a/src/components/ConnectRequest.js
+++ b/src/components/ConnectRequest.js
@@ -5,7 +5,7 @@ import Modal from 'react-native-modal';
 import CompleteIcon from '@components/common/CompleteIcon';
 import ConnectRequestIcon from '@components/common/ConnectRequestIcon';
 
-const ConnectRequest = ({ modalVisible, setModalVisible }) => {
+const ConnectRequest = ({ modalVisible, setModalVisible, textLoading='커넥트 요청중', textComplete='커넥트 요청 완료!' }) => {
   const [showConnectRequest, setShowConnectRequest] = useState(true);
   const [showConnectComplete, setShowConnectComplete] = useState(false);
 
@@ -39,7 +39,7 @@ const ConnectRequest = ({ modalVisible, setModalVisible }) => {
               <ConnectRequestIcon />
             </View>
             <View style={styles.connectTextView}>
-              <Text style={styles.connectText}>커넥트 요청중</Text>
+              <Text style={styles.connectText}>{textLoading}</Text>
             </View>
           </View>
         )}
@@ -48,7 +48,7 @@ const ConnectRequest = ({ modalVisible, setModalVisible }) => {
           <View style={styles.connectContainer}>
             <CompleteIcon isConnect={true}/>
             <View style={styles.connectTextView}>
-              <Text style={styles.connectText}>커넥트 요청 완료!</Text>
+              <Text style={styles.connectText}>{textComplete}</Text>
             </View>
           </View>
         )}

--- a/src/components/common/ApplyButton.js
+++ b/src/components/common/ApplyButton.js
@@ -69,7 +69,6 @@ const styles = StyleSheet.create({
   },
   apply: {
     flexDirection: 'row',
-    width: '90%',
     height: 44,
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/pages/login/FindPasswordPage.js
+++ b/src/pages/login/FindPasswordPage.js
@@ -59,20 +59,20 @@ const FindPasswordPage = () => {
                 <Text style={FindPasswordStyles.textTitle}>비밀번호 재발급</Text>
                 <Text style={FindPasswordStyles.textSubTitle}>회원가입 시 사용한 이메일을 입력해주세요</Text>
                 <Text style={FindPasswordStyles.textId}>ID (Email Address)</Text>
-                <TextInput style={FindPasswordStyles.textInputId}
-                    placeholder="이메일을 입력해주세요"
-                    onChangeText={text => onChangeID(text)}
-                    value={valueID}
-                />
+                <View style={FindPasswordStyles.textInputId}>
+                    <TextInput
+                        placeholder="이메일을 입력해주세요"
+                        onChangeText={text => onChangeID(text)}
+                        value={valueID}
+                    />
+                </View>
                 {idValid == false && (
                     <View style={FindPasswordStyles.containerNotMember}>
                         <InfoCircle color={CustomTheme.warningRed}/>
                         <Text style={FindPasswordStyles.textNotMember}>등록된 회원정보가 없습니다</Text>
                     </View>
                 )}
-                <View style={FindPasswordStyles.buttonPasswordReissue}>
-                    <ApplyButton text="비밀번호 재발급받기" onPress={handleFindPassword}/>
-                </View>
+                <ApplyButton text="비밀번호 재발급받기" onPress={handleFindPassword}/>
                 <ConnectRequest
                     modalVisible={modalConnectVisible}
                     setModalVisible={setModalConnectVisible}

--- a/src/pages/login/FindPasswordPage.js
+++ b/src/pages/login/FindPasswordPage.js
@@ -9,6 +9,7 @@ import { CustomTheme } from '@styles/CustomTheme.js';
 import InfoCircle from '@components/common/InfoCircle';
 import ArrowRight32 from '@components/Icon32/ArrowRight32';
 import ApplyButton from '@components/common/ApplyButton';
+import ConnectRequest from '@components/ConnectRequest';
 
 const FindPasswordPage = () => {
     const [valueID, onChangeID] = useState('');
@@ -25,10 +26,12 @@ const FindPasswordPage = () => {
     };
 
     const handleFindPassword = () => {
+        setModalConnectVisible(true);
+
         const formData = new FormData();
         formData.append('email', valueID);
     
-        axios.put('http://192.168.45.87:8080/api/members/change-password', formData, {
+        axios.put('http://192.168.45.92:8080/api/members/change-password', formData, {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Accept': 'application/json',
@@ -44,6 +47,8 @@ const FindPasswordPage = () => {
             setIdValid(false);
         });
     };
+
+    const [ modalConnectVisible, setModalConnectVisible ] = useState(false);
 
     return (
         <TouchableWithoutFeedback onPress={handleKeyboard}>
@@ -68,6 +73,11 @@ const FindPasswordPage = () => {
                 <View style={FindPasswordStyles.buttonPasswordReissue}>
                     <ApplyButton text="비밀번호 재발급받기" onPress={handleFindPassword}/>
                 </View>
+                <ConnectRequest
+                    modalVisible={modalConnectVisible}
+                    setModalVisible={setModalConnectVisible}
+                    textLoading='이메일 전송중'
+                    textComplete='이메일 전송 완료!' />
             </SafeAreaView>
         </TouchableWithoutFeedback>
     )

--- a/src/pages/login/FindPasswordStyles.js
+++ b/src/pages/login/FindPasswordStyles.js
@@ -30,7 +30,6 @@ const FindPasswordStyles = StyleSheet.create({
         marginLeft: 24,
     },
     textInputId: {
-        width: 327,
         height: 44,
         padding: 12,
         borderWidth: 1,
@@ -38,7 +37,7 @@ const FindPasswordStyles = StyleSheet.create({
         borderRadius: 6,
         marginTop: 8,
         marginHorizontal: 25,
-        alignItems: 'center',
+        justifyContent: 'center',
     },
     containerNotMember: {
         flexDirection: 'row',

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -68,17 +68,17 @@ const LoginPage = () => {
         <TouchableWithoutFeedback onPress={handleKeyboard}>
         <SafeAreaView style={[LoginStyles.container]}>
             <LoginBackground style={LoginStyles.backgroundLogin}/>
-            <Text style={LoginStyles.TextTitle}>{loginData[0]}</Text>
-            <Text style={LoginStyles.TextSubTitle}>{loginData[1]}</Text>
-            <Text style={LoginStyles.TextId}>ID (Email Address)</Text>
-            <TextInput style={loginFailed ? [LoginStyles.TextInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.TextInputId}
+            <Text style={LoginStyles.textTitle}>{loginData[0]}</Text>
+            <Text style={LoginStyles.textSubTitle}>{loginData[1]}</Text>
+            <Text style={LoginStyles.textId}>ID (Email Address)</Text>
+            <TextInput style={loginFailed ? [LoginStyles.textInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.textInputId}
                 placeholder="이메일을 입력해주세요"
                 onChangeText={text => onChangeID(text)}
                 value={valueID}
             />
-            <Text style={LoginStyles.TextPw}>Password</Text>
-            <View style={LoginStyles.TextInputPwContainer}>
-                <TextInput style={loginFailed ? [LoginStyles.TextInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.TextInputPw}
+            <Text style={LoginStyles.textPw}>Password</Text>
+            <View style={LoginStyles.textInputPwContainer}>
+                <TextInput style={loginFailed ? [LoginStyles.textInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.textInputPw}
                     placeholder="비밀번호를 입력해주세요"
                     onChangeText={text => onChangePW(text)}
                     value={valuePW}
@@ -100,7 +100,7 @@ const LoginPage = () => {
                     <View text='로그인' onPress={handleLogin} />
                 </BottomTwoButtons>
                 <TouchableOpacity onPress={() => navigation.navigate('FindPassword')}>
-                    <Text style={LoginStyles.TextReport}>비밀번호를 까먹었어요</Text>
+                    <Text style={LoginStyles.textReport}>비밀번호를 까먹었어요</Text>
                 </TouchableOpacity>
             </View>
         </SafeAreaView>

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -6,12 +6,12 @@ import axios from 'axios';
 import { CustomTheme } from '@styles/CustomTheme';
 import LoginStyles from '@pages/login/LoginStyles';
 
-import Checkbox from '@components/common/Checkbox';
 import BottomTwoButtons from '@components/common/BottomTwoButtons';
 import IconNotSeePw from '@components/login/IconNotSeePw';
 import IconSeePw from '@components/login/IconSeePw';
 import LoginBackground from '@components/login/LoginBackground';
 import { useOnboarding } from 'src/states/OnboardingContext.js';
+import InfoCircle from '@components/common/InfoCircle';
 
 const LoginPage = () => {
     const navigation = useNavigation();
@@ -37,8 +37,10 @@ const LoginPage = () => {
         navigation.navigate('SignUp')
     };
 
+    const [loginFailed, setLoginFailed] = useState(false);
+
     const handleLogin = () => {
-        axios.post(`http://192.168.45.87:8080/api/members/login?email=${valueID}&password=${valuePW}`, {
+        axios.post(`http://192.168.45.92:8080/api/members/login?email=${valueID}&password=${valuePW}`, {
         email: valueID,
         password: valuePW,
         }, {
@@ -58,6 +60,7 @@ const LoginPage = () => {
         })
         .catch(error => {
             console.error('로그인 오류:', error.response ? error.response.data : error.message);
+            setLoginFailed(true);
         });
         };
 
@@ -68,14 +71,14 @@ const LoginPage = () => {
             <Text style={LoginStyles.TextTitle}>{loginData[0]}</Text>
             <Text style={LoginStyles.TextSubTitle}>{loginData[1]}</Text>
             <Text style={LoginStyles.TextId}>ID (Email Address)</Text>
-            <TextInput style={LoginStyles.TextInputId}
+            <TextInput style={loginFailed ? [LoginStyles.TextInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.TextInputId}
                 placeholder="이메일을 입력해주세요"
                 onChangeText={text => onChangeID(text)}
                 value={valueID}
             />
             <Text style={LoginStyles.TextPw}>Password</Text>
             <View style={LoginStyles.TextInputPwContainer}>
-                <TextInput style={LoginStyles.TextInputPw}
+                <TextInput style={loginFailed ? [LoginStyles.TextInputPw, {borderColor: CustomTheme.warningRed}] : LoginStyles.TextInputPw}
                     placeholder="비밀번호를 입력해주세요"
                     onChangeText={text => onChangePW(text)}
                     value={valuePW}
@@ -85,10 +88,12 @@ const LoginPage = () => {
                     { valuePW == '' ? null : (showPW ? <IconSeePw /> : <IconNotSeePw />)}
                 </TouchableOpacity>
             </View>
-            <Checkbox style={LoginStyles.checkboxRememberMe}
-                checked='false'
-                text='자동 로그인'
-                login='true' />
+            {loginFailed && (
+                <View style={LoginStyles.containerError}>
+                    <InfoCircle color={CustomTheme.warningRed} />
+                    <Text style={LoginStyles.textError}>입력하신 아이디 또는 비밀번호를 확인해주세요</Text>
+                </View>
+            )}
             <View style={LoginStyles.ButtonSignupPwContainer}>
                 <BottomTwoButtons>
                     <View text='회원가입' onPress={handleSignUp} />

--- a/src/pages/login/LoginStyles.js
+++ b/src/pages/login/LoginStyles.js
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { CustomTheme } from '@styles/CustomTheme';
 
-const { fontHead18, fontSub14, fontBody14 } = CustomTheme;
+const { fontHead18, fontSub14, fontBody14, fontCaption } = CustomTheme;
 
 const LoginStyles = StyleSheet.create({
     container: {
@@ -72,12 +72,18 @@ const LoginStyles = StyleSheet.create({
         top: 17,
         right: 50,
     },
-    checkboxRememberMe: {
-        color: CustomTheme.textSecondary,
-        marginLeft: 24,
+    containerError: {
+        flexDirection: 'row',
+        marginTop: 8,
+        marginLeft: 25,
+    },
+    textError: {
+        ...fontCaption,
+        color: CustomTheme.warningRed,
+        marginLeft: 3,
     },
     ButtonSignupPwContainer: {
-        marginTop: 144,
+        marginTop: 170,
         alignItems: 'center',
     },
     TextReport: {

--- a/src/pages/login/LoginStyles.js
+++ b/src/pages/login/LoginStyles.js
@@ -13,7 +13,7 @@ const LoginStyles = StyleSheet.create({
         top: 124,
         left: -70,
     },
-    TextTitle: {
+    textTitle: {
         fontSize: 32,
         lineHeight: 37,
         fontFamily: 'NotoSansCJKkr-Bold',
@@ -21,19 +21,19 @@ const LoginStyles = StyleSheet.create({
         marginTop: 67,
         marginLeft: 24,
     },
-    TextSubTitle: {
+    textSubTitle: {
         ...fontHead18,
         color: CustomTheme.textSecondary,
         marginTop: 12,
         marginLeft: 24,
     },
-    TextId: {
+    textId: {
         ...fontSub14,
         color: CustomTheme.textPrimary,
         marginTop: 127,
         marginLeft: 24,
     },
-    TextInputId: {
+    textInputId: {
         width: 327,
         height: 44,
         padding: 12,
@@ -44,18 +44,18 @@ const LoginStyles = StyleSheet.create({
         marginHorizontal: 25,
         alignItems: 'center',
     },
-    TextPw: {
+    textPw: {
         ...fontSub14,
         color: CustomTheme.textPrimary,
         marginTop: 12,
         marginLeft: 24,
     },
-    TextInputPwContainer: {
+    textInputPwContainer: {
         position: 'relative',
         flexDirection: 'row',
         alignItems: 'center',
       },
-    TextInputPw: {
+    textInputPw: {
         width: 327,
         height: 44,
         padding: 12,
@@ -86,7 +86,7 @@ const LoginStyles = StyleSheet.create({
         marginTop: 170,
         alignItems: 'center',
     },
-    TextReport: {
+    textReport: {
         ...fontBody14,
         color: CustomTheme.textSecondary,
         textDecorationLine: 'underline',

--- a/src/pages/login/SignUpPage.js
+++ b/src/pages/login/SignUpPage.js
@@ -9,6 +9,8 @@ import { CustomTheme } from '@styles/CustomTheme.js';
 import ArrowRight32 from '@components/Icon32/ArrowRight32';
 import ApplyButton from '@components/common/ApplyButton';
 import InfoCircle from '@components/common/InfoCircle';
+import IconNotSeePw from '@components/login/IconNotSeePw';
+import IconSeePw from '@components/login/IconSeePw';
 
 const SignUpPage = () => {
     const navigation = useNavigation();
@@ -32,8 +34,12 @@ const SignUpPage = () => {
         navigation.goBack();
     };
 
+    const handleShowPW = () => {
+        setShowPW(!showPW);
+    };
+
     const handlePasswordError = () => {
-        const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
+        const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
         setPasswordError(!passwordRegex.test(valuePW));
     };
 
@@ -92,8 +98,12 @@ const SignUpPage = () => {
                     placeholder="영문, 숫자 포함 8자 이상"
                     onChangeText={text => onChangePW(text)}
                     value={valuePW}
+                    secureTextEntry={!showPW}
                     onBlur={handlePasswordError}
                 />
+                <TouchableOpacity style={SignUpStyles.iconSee} onPress={handleShowPW}>
+                    { valuePW == '' ? null : (showPW ? <IconSeePw /> : <IconNotSeePw />)}
+                </TouchableOpacity>
             </View>
             {passwordError && (
                 <View style={SignUpStyles.containerError}>

--- a/src/pages/login/SignUpStyles.js
+++ b/src/pages/login/SignUpStyles.js
@@ -58,6 +58,12 @@ const SignUpStyles = StyleSheet.create({
         marginHorizontal: 25,
         alignItems: 'center',
     },
+    iconSee: {
+        position: 'absolute',
+        alignItems: 'center',
+        top: 17,
+        right: 50,
+    },
     containerError: {
         flexDirection: 'row',
         marginTop: 8,


### PR DESCRIPTION
### 개요
loginpage 디자인 요소 추가 및 비밀번호 재발급 페이지 로딩 모달 추가
<br>

### 수정사항
디자인적으로 이전에 미처 추가하지 못한 부분 및 추후 회의를 통해 변경됐던 부분들 추가하였습니다.
- 온보딩을 완료했다면 무조건 자동로그인이 되므로, 자동로그인 옵션 디자인적으로 삭제 + 로그인 실패 시의 오류 글자 추가
- loginpage 스타일 변수명 중 일부 PascalCase로 되어 있던 부분을 CamelCase로 변경
- 비밀번호 재발급 페이지에서 재발급받기를 눌렀을 때의 로딩 모달 추가
  - 요청할 때마다 요청 시간이 조금씩 달라지는 거 같은데, 일단 기존 모달을 활용했기 때문에 현재는 0.83초입니다. 만약 더 길게 모달이 띄워져야 할 거 같다면 수정하겠습니다!
- 비밀번호 재발급 페이지에서 대칭이 안 맞는 문제를 해결하기 위한 스타일 수정
<br>

### 테스트 화면
<img src="https://github.com/team-diverse/dife-frontend/assets/104901660/be59881f-7ff7-4038-a020-d78791854b79" width="40%" height="40%">
<img src="https://github.com/team-diverse/dife-frontend/assets/104901660/9faedc56-cd39-49fb-8e1f-1c086c6b1da3" width="40%" height="40%">
<img src="https://github.com/team-diverse/dife-frontend/assets/104901660/24d6267f-9558-4997-84ec-3c9dac88b308" width="40%" height="40%">
