### PR TITLE
feat(chat): 채팅방 목록을 가져오고 최신 채팅을 불러오기 구현

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -102,20 +102,6 @@ function ChattingStack() {
 }
 
 function MainTabs() {
-    const { ws, publishMessage } = useWebSocket();
-
-    useEffect(() => {
-        if (ws.current) {
-            const message = {
-                chatroomType: "GROUP",
-                chatType: "CHAT",
-                message: "Hi, guys By 2",
-                chatroomId: 1,
-                memberId: 2
-            };
-            publishMessage(message);
-        }
-    }, []);
     return (
         <Tab.Navigator
             initialRouteName="Home"

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, SafeAreaView, FlatList, Keyboard, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import axios from 'axios';
@@ -12,74 +12,21 @@ import IconBookmark from '@components/chat/IconBookmark';
 import ChatRoomList from '@components/chat/ChatRoomList';
 import ConnectReset from '@components/connect/ConnectReset';
 import IconChatPlus from '@components/chat/IconChatPlus';
+import { useWebSocket } from 'context/WebSocketContext';
 
 const ChattingPage = () => {
   const navigation = useNavigation();
 
-  const chatData = [
-    {
-      id: '1',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '2',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '3',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '4',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '5',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '6',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '7',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-    {
-      id: '8',
-      profile: require('@assets/images/test_img/test_connectProfile.jpeg'),
-      name: 'Amy',
-      context: 'nec non. lorem. luctus ac Donec non, efficitur. diam vitae ame ...',
-      time: '09:25',
-    },
-  ]
-
+  const { chatrooms, messages } = useWebSocket();
   const [searchTerm, setSearchTerm] = useState('');
   const [searchData, setSearchData] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
 
-  const [chatListCount, setChatListCount] = useState(1);
+
+  const getLatestChatByChatroomId = id => {
+    const chats = messages[id] || [];
+    return chats.length ? chats[chats.length - 1].message : '';
+  }
 
   const [isIndividualTab, setIsIndividualTab] = useState(false);
 
@@ -159,17 +106,17 @@ const ChattingPage = () => {
           {isIndividualTab ? (
             <></>
           ) : (
-            chatListCount ? (
+            chatrooms.length ? (
               <View style={ChattingStyles.containerChatItems}>
                 <View style={ChattingStyles.flatlist}>
                   <FlatList
                     contentContainerStyle={ChattingStyles.flatlistContent}
-                    data={chatData}
+                    data={chatrooms}
                     renderItem={({ item }) => (
                         <ChatRoomList
                           name={item.name}
-                          context={item.context}
-                          time={item.time}
+                          context={getLatestChatByChatroomId(item.id)}
+                          time={item.created}
                         />
                       )}
                       keyExtractor={item => item.id}


### PR DESCRIPTION
### 개요

- 유저가 존재하하는 채팅방 목록을 가져오고 각 채팅방 별로 메시지를
가져오게 한다

### 수정 사항

- `WebSocketContext.js`
  - `channel` 이름을 `chatrooms`로 변경함
  - 채팅방에 포함된 채팅 이력을 `messages`로 따로 상태 관리를 함
  - `chatrooms`, `messages`를 `useRef`가 아닌 `useState`로 관리하는 이유는,
이들이 변경 시, 채팅방의 UI가 변변경되어야하기 때문에 변경함. 렌더링
최적화는 이후 작업 예예정
  - `onConnect`에서서 채팅방의 목록과 기존에에 있던 과거 채팅들을
불러와서 상태 저저장을 하고 각 채팅방에 구독하도록 구성함

  - `handleIncoming`은 새로운 메시지가 오면 message 상태를 업데이트함
  - 현재 백엔드에서 채팅 정렬이 되지 않아아 id로 id로 한번 sort함. 다만,
이는 시일내에 백엔드에도 반영하고 해당 코드는 삭제할 예정
  - 불필요한 `getChannelIdsFromData`와 `ConnectWebsocket`등 일부 삭제

- `ChattingPage.jsx`
  - 하드코딩된 데이터 삭제
  - 채팅방에서 제일 최근의 메시지가 표시될 수 있도록
`getLatestChatByChatroomId` 작성
  - 불필요한 `count` 변수 삭제