### PR TITLE
feat(chat): 채팅의 시간 표시 및 시간 형식 변환 코드 작성

### DIFF
--- a/src/context/WebSocketContext.js
+++ b/src/context/WebSocketContext.js
@@ -63,7 +63,7 @@ export const WebSocketProvider = ({ children }) => {
             if (!updatedMessages[chatroomId]) {
                 updatedMessages[chatroomId] = [];
             }
-            updatedMessages[chatroomId].push({message});
+            updatedMessages[chatroomId].push(JSON.parse(message));
             return updatedMessages;
         });
     }

--- a/src/pages/chat/ChatBubble/ChatBubble.jsx
+++ b/src/pages/chat/ChatBubble/ChatBubble.jsx
@@ -12,8 +12,10 @@ const ChatBubble = ({ message, time, isMine}) => {
     
     return (
         <View style={rowStyles}>
-            <Text style={styles.time}>{time}</Text>
             <View style={frameParentStyles}>
+                <View style={styles.timeWrapper}>
+                    <Text style={styles.time}>{time}</Text>
+                </View>
                 <View style={bubbleStyles}>
                     <Text style={messageStyles}>{message}</Text>
                 </View>
@@ -24,6 +26,9 @@ const ChatBubble = ({ message, time, isMine}) => {
 };
 
 const styles = StyleSheet.create({
+    timeWrapper: {
+        marginTop: "auto",
+    },
     time: {
         fontSize: 8,
         lineHeight: 11,
@@ -31,7 +36,7 @@ const styles = StyleSheet.create({
         textAlign: "center",
         display: "flex",
         justifyContent: "center",
-        width: 33,
+        width: 40,
         height: 15,
         alignItems: "center",
         fontFamily: "Noto Sans CJK KR",

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -14,6 +14,7 @@ import IconChatNotification from '@components/chat/IconChatNotification'
 import IconChatSetting from '@components/chat/IconChatSetting'
 import ChatBubble from './ChatBubble/ChatBubble';
 import { useWebSocket } from 'context/WebSocketContext';
+import formatKoreanTime from 'util/formatTime';
 
 const ChatRoomPage = ({route}) => {
     const navigation = useNavigation();
@@ -70,7 +71,12 @@ const ChatRoomPage = ({route}) => {
                     <FlatList 
                         data={messages[chatroomId] || []}
                         keyExtractor={item => item.id}
-                        renderItem={({item}) => <ChatBubble {...item} />}
+                        renderItem={({item}) => (
+                            <ChatBubble 
+                                message={item.message}
+                                time={formatKoreanTime(item.created)}
+                                isMine={true}/>
+                        )}
                     />
                 </View>
                 <ChatInputSend />

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -12,6 +12,7 @@ import IconBookmark from '@components/chat/IconBookmark';
 import IconChatPlus from '@components/chat/IconChatPlus';
 import { useWebSocket } from 'context/WebSocketContext';
 import ChatroomItem from '@components/chat/ChatroomItem';
+import formatKoreanTime from 'util/formatTime';
 
 const ChattingPage = () => {
   const navigation = useNavigation();
@@ -116,7 +117,7 @@ const ChattingPage = () => {
                           id={item.id}
                           name={item.name}
                           context={getLatestChatByChatroomId(item.id)}
-                          time={item.created}
+                          time={formatKoreanTime(item.created)}
                         />
                       )}
                       keyExtractor={item => item.id}

--- a/src/util/formatTime.js
+++ b/src/util/formatTime.js
@@ -1,0 +1,11 @@
+const formatKoreanTime = (isoString) => {
+    const date = new Date(isoString);
+    const formatter = new Intl.DateTimeFormat("ko-KR", {
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+    });
+    return formatter.format(date);
+};
+
+export default formatKoreanTime;


### PR DESCRIPTION
### 개요

- 채팅의 시간을 형식에 맞게 표시한다.

### 수정 사항

- formatTime.js라는 util 스크립트를 만들어서 백엔드에서 ISO 포맷으로 오는 코드를 "오후 XX:XX"의 형식으로 변환 함수 작성
- ChatBubble에서 채팅 시간의 적절한 위치를 위해 새로운 View 추가 및 marginTop:auto 부여 + width 늘려 text가 개행되지 않도록 함
- ChattingPage와 ChattingRoomPage에서 formatTime 적용된 시간 보여줌
- 아울러, message를 웹소켓으로 받을때, JSON.parse를 해서 시간적용 시 에러가 나는 것을 해결함 (기존에 놓치고 있던 에러가 있었음)

### 참고

- 우선은 한국 시간으로만 변환하는 함수만 작성 이후에 변화에 유연하게 작성 예정