### PR TITLE
feat(chat): 상대방 채팅, 내 채팅 구분하는 채팅 코드 구현

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import * as SecureStore from "expo-secure-store";
 
 const BACKEND_URL = "http://192.168.0.30:8080/api";
 
@@ -9,8 +10,8 @@ export const api = axios.create({
     }
 });
 
-api.interceptors.request.use((config) => {
-    const token = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwidHlwZSI6ImFjY2Vzc1Rva2VuIiwiaXNzIjoiZGlmZSIsImlhdCI6MTcxNzUxNjg2MywiZXhwIjoxNzE3NTIwNDYzfQ.Lp6ul_eKDsis-RPO8gofD2NwDncQiU6deHzh0gXVQLY"
+api.interceptors.request.use(async (config) => {
+    const token = await SecureStore.getItemAsync("accessToken");
     if (token) {
         config.headers["Authorization"] = "Bearer " + token;
     }
@@ -19,11 +20,11 @@ api.interceptors.request.use((config) => {
 
 export const getChatroomsByType = (type) => {
     return api.get("/chatrooms", {
-            params: {
+        params: {
             chatroomType: type,
         },
     });
-            }
+}
 
 export const signUp = (email, password) => {
     return api.post("/members/register", {
@@ -36,7 +37,7 @@ export const login = (email, password) => {
     return api.post("/members/login", {
         email,
         password,
-        });
+    });
 }
 
 export const changePassword = (email) => {

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -15,6 +15,7 @@ import IconChatSetting from '@components/chat/IconChatSetting'
 import ChatBubble from './ChatBubble/ChatBubble';
 import { useWebSocket } from 'context/WebSocketContext';
 import formatKoreanTime from 'util/formatTime';
+import * as SecureStore from 'expo-secure-store';
 
 const ChatRoomPage = ({route}) => {
     const navigation = useNavigation();
@@ -25,6 +26,15 @@ const ChatRoomPage = ({route}) => {
     const menuAnim = useRef(new Animated.Value(screenWidth)).current;
     const { messages } = useWebSocket();
     const { chatroomId } = route.params;
+    const [memberId, setMemberId] = useState(null);
+
+    useEffect(() => {
+        const getMemberId = async () => {
+            const id = await SecureStore.getItemAsync('memberId');
+            setMemberId(parseInt(id));
+        }
+        getMemberId();
+    }, []);
 
     const handleKeyboard = () => {
         Keyboard.dismiss();
@@ -75,7 +85,7 @@ const ChatRoomPage = ({route}) => {
                             <ChatBubble 
                                 message={item.message}
                                 time={formatKoreanTime(item.created)}
-                                isMine={true}/>
+                                isMine={item.member.id === memberId}/>
                         )}
                     />
                 </View>

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -45,7 +45,7 @@ const LoginPage = () => {
             const accessToken = loginResponse.data.accessToken;
             const refreshToken = loginResponse.data.refreshToken;
 
-            await SecureStore.setItemAsync('member_id', JSON.stringify(id));   
+            await SecureStore.setItemAsync('memberId', JSON.stringify(id));   
             await SecureStore.setItemAsync('accessToken', accessToken);
             await SecureStore.setItemAsync('refreshToken', refreshToken);
     


### PR DESCRIPTION
### 개요

- 상대방의 채팅과 본인의 채팅이 구분되도록 한다.
- 채팅이 구분되도록 하려면, 로그인 시에, SecureStore에 해당 멤버의 id를 저장해야하므로 로그인 시 이를 저장하고 모든 API request 시에 자동으로 Bearer Token으로 들어가게끔 구현한다.