### PR TITLE
Feat/home connect card

### DIFF
--- a/src/components/common/Tag.jsx
+++ b/src/components/common/Tag.jsx
@@ -8,7 +8,7 @@ const Tag = ({tag=['tag']}) => {
   return (
     <View style={styles.container}>
       {tag.map((item, index) => (
-        <View key={index} style={[styles.rectangle, { width: item.length * 10 + 1 }]}>
+        <View key={index} style={[styles.rectangle, { width: item.length + 50 }]}>
           <Text style={styles.text}>{item}</Text>
         </View>
       ))}
@@ -31,6 +31,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginRight: 8,
+    marginBottom: 8,
   },
   text: {
     ...fontCaption,

--- a/src/components/connect/ConnectCard.js
+++ b/src/components/connect/ConnectCard.js
@@ -10,7 +10,7 @@ import Tag from "@components/common/Tag";
 const { fontSub14, fontCaption } = CustomTheme;
 
 const ConnectCard = ({
-    profileFileName = null,
+    profilePresignUrl = null,
     username = "username",
     country = "country",
     age = "age",
@@ -28,7 +28,7 @@ const ConnectCard = ({
     return (
         <View style={styles.rectangle}>
             <View style={styles.profile}>
-                <Image source={profileFileName} style={styles.imgProfile} />
+                <Image source={{url: profilePresignUrl}} style={styles.imgProfile} />
             </View>
             <View style={styles.cardContainer}>
                 <View style={styles.textIconContainer}>

--- a/src/components/connect/ConnectCard.js
+++ b/src/components/connect/ConnectCard.js
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native";
 
 import IconHeart24 from "@components/Icon24/IconHeart24";
 import ConnectPlusIcon from "@components/connect/ConnectPlusIcon";
-import Tag from "@components/Tag.js";
+import Tag from "@components/common/Tag";
 
 const { fontSub14, fontCaption } = CustomTheme;
 
@@ -108,6 +108,7 @@ const styles = StyleSheet.create({
     },
     tagContainer: {
         flexDirection: "row",
+        width: 221,
     },
 });
 

--- a/src/components/home/HomeCardFront.jsx
+++ b/src/components/home/HomeCardFront.jsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
 import { CustomTheme } from '@styles/CustomTheme';
 
-import Tag from '@components/Tag';
+import Tag from "@components/common/Tag";
 import HomeProfile from '@components/home/HomeProfile';
 import IconHeart24 from '@components/Icon24/IconHeart24';
 import IconAddFriend24 from '@components/Icon24/IconAddFriend24';
@@ -65,15 +65,15 @@ const styles = StyleSheet.create({
   },
   tagContainer: {
       flexDirection: 'row',
+      width: 200,
       marginTop: 12,
       marginBottom: 6,
   },
   introduction: {
       ...fontCaption,
       width: 200,
-      height: 51,
       marginTop: 6,
-      marginBottom: 6,
+      marginBottom: 12,
   },
   myinfoContainer: {
       flexDirection: 'row',

--- a/src/components/home/HomeProfile.js
+++ b/src/components/home/HomeProfile.js
@@ -7,7 +7,7 @@ const HomeProfile = ({ profile=null, back=false }) => {
 
   return (
     <View style={[styles.rectangle, containerStyle]}>
-      <Image source={profile} style={styles.image} />
+      <Image source={{url: profile}} style={styles.image} />
     </View>
   );
 };

--- a/src/pages/community/CommunityStyles.jsx
+++ b/src/pages/community/CommunityStyles.jsx
@@ -88,8 +88,6 @@ const ChattingStyles = StyleSheet.create({
         marginLeft: 24,
     },
     iconArrow: {
-        // width: 24,
-        // height: 24,
         transform: [{ scaleX: -1 }],
         marginRight: 24,
     },

--- a/src/pages/connect/ConnectPage.js
+++ b/src/pages/connect/ConnectPage.js
@@ -25,11 +25,20 @@ const ConnectPage = () => {
   const RANDOM_MEMBER_COUNT = 10;
 
   const cardProfiles = () => {
-      getRandomMembersByCount(RANDOM_MEMBER_COUNT) 
+    axios.get('http://192.168.45.135:8080/api/members/random?count=10', {
+      headers: {
+        'Authorization': `Bearer ${onboardingData.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      })
       .then(response => {
+        function cleanHobbies(hobbies) {
+          return hobbies.map(hobby => hobby.replace(/[\[\]"]/g, ''));
+        }
         const updatedData = response.data.map(data => {
           if (data.mbti !== null) {
-            const tags = [data.mbti, ...data.hobbies];
+            const cleanedHobbies = cleanHobbies(data.hobbies);
+            const tags = [data.mbti, ...cleanedHobbies];
             return { ...data, tags };
           }
           return data;

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -35,6 +35,7 @@ const HomePage = ({cnt=3}) => {
       },
       })
       .then(response => {
+        // console.log(response.data);
         function cleanHobbies(hobbies) {
           return hobbies.map(hobby => hobby.replace(/[\[\]"]/g, ''));
         }
@@ -46,6 +47,7 @@ const HomePage = ({cnt=3}) => {
           }
           return data;
         });
+        // console.log(updatedData);
         setProfileDataList(updatedData);
       })
       .catch(error => {
@@ -74,6 +76,10 @@ const HomePage = ({cnt=3}) => {
 
   const profileData = profileDataList[currentProfileIndex];
   const { id, profilePresignUrl, tags, bio, username, country, age } = profileData ? profileData : { profileFileName: null, tags: ["tag"], bio: "bio", username: "username", country: "country", age: "age" };
+
+  // useEffect(() => {
+  //   console.log(profilePresignUrl);
+  // }, [profileDataList[currentProfileIndex]])
 
   const [showNewCard, setShowNewCard] = useState(false);
   const [isLiked, setIsLiked] = useState({});
@@ -113,7 +119,7 @@ const HomePage = ({cnt=3}) => {
           {showNewCard ? (
             <View style={HomeStyles.homecardContainer}>
               <View style={HomeStyles.homecard}>
-                <HomeCardBack profileImg={profileFileName} name={username} onPress={() => setShowNewCard(false)}/>
+                <HomeCardBack profileImg={profilePresignUrl} name={username} onPress={() => setShowNewCard(false)}/>
               </View>
             </View>
           ) : showMoreProfiles ? (

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -35,7 +35,6 @@ const HomePage = ({cnt=3}) => {
       },
       })
       .then(response => {
-        // console.log(response.data);
         function cleanHobbies(hobbies) {
           return hobbies.map(hobby => hobby.replace(/[\[\]"]/g, ''));
         }
@@ -47,7 +46,6 @@ const HomePage = ({cnt=3}) => {
           }
           return data;
         });
-        // console.log(updatedData);
         setProfileDataList(updatedData);
       })
       .catch(error => {
@@ -76,10 +74,6 @@ const HomePage = ({cnt=3}) => {
 
   const profileData = profileDataList[currentProfileIndex];
   const { id, profilePresignUrl, tags, bio, username, country, age } = profileData ? profileData : { profileFileName: null, tags: ["tag"], bio: "bio", username: "username", country: "country", age: "age" };
-
-  // useEffect(() => {
-  //   console.log(profilePresignUrl);
-  // }, [profileDataList[currentProfileIndex]])
 
   const [showNewCard, setShowNewCard] = useState(false);
   const [isLiked, setIsLiked] = useState({});

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -28,11 +28,20 @@ const HomePage = ({cnt=3}) => {
   const RANDOM_MEMBER_COUNT = 10;
 
   useEffect(() => {
-    getRandomMembersByCount(RANDOM_MEMBER_COUNT)
+    axios.get('http://192.168.45.135:8080/api/members/random?count=10', {
+      headers: {
+        'Authorization': `Bearer ${onboardingData.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      })
       .then(response => {
+        function cleanHobbies(hobbies) {
+          return hobbies.map(hobby => hobby.replace(/[\[\]"]/g, ''));
+        }
         const updatedData = response.data.map(data => {
           if (data.mbti !== null) {
-            const tags = [data.mbti, ...data.hobbies];
+            const cleanedHobbies = cleanHobbies(data.hobbies);
+            const tags = [data.mbti, ...cleanedHobbies];
             return { ...data, tags };
           }
           return data;
@@ -64,7 +73,7 @@ const HomePage = ({cnt=3}) => {
   };
 
   const profileData = profileDataList[currentProfileIndex];
-  const { id, profileFileName, tags, bio, username, country, age } = profileData ? profileData : { profileFileName: null, tags: ["tag"], bio: "bio", username: "username", country: "country", age: "age" };
+  const { id, profilePresignUrl, tags, bio, username, country, age } = profileData ? profileData : { profileFileName: null, tags: ["tag"], bio: "bio", username: "username", country: "country", age: "age" };
 
   const [showNewCard, setShowNewCard] = useState(false);
   const [isLiked, setIsLiked] = useState({});
@@ -117,7 +126,7 @@ const HomePage = ({cnt=3}) => {
             <View style={HomeStyles.homecardContainer}>
               <View style={HomeStyles.homecard}>
                 <HomeCardFront
-                  profileImg={profileFileName}
+                  profileImg={profilePresignUrl}
                   tags={tags}
                   introduction={bio}
                   name={username}


### PR DESCRIPTION
### 개요
homePage 및 connectPage의 card 관련 수정
<br>

### 수정사항
- 홈 및 커넥트 카드의 hobby 형식 수정 및 스타일 세부 조정
  - [, " 등과 함께 나오던 hobby의 형식 수정
  - 태그가 최대 4개가 될 수 있기 때문에, 그에 따른 스타일 세부 조정 (기존 스타일은 3개 기준)
- 홈 및 커넥트 카드의 프로필 이미지를 불러오기 위한 백엔드 연결
<br>

### 테스트 화면
<img src="https://github.com/team-diverse/dife-frontend/assets/104901660/fcc237dc-ced9-481a-a9f2-b2e43efd6792" width="40%" height="40%">
<img src="https://github.com/team-diverse/dife-frontend/assets/104901660/e5852985-87fb-4287-856a-3c16f0c817dc" width="40%" height="40%">

