### PR TITLE
chore(ramp): UI 테스트 중 귀찮은 로그인 과정을 스킵하는 설정 생성

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -22,7 +22,6 @@ module.exports = function (api) {
 					envName: "LOCAL_ENV",
 					moduleName: "@env",
 					path: ".evn.local",
-					allowUndefined: false,
 				},
 			],
 		],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"main": "node_modules/expo/AppEntry.js",
 	"scripts": {
-		"start": "expo start",
+		"start": "expo start -c",
 		"tunnel": "expo start --tunnel",
 		"android": "expo start --android",
 		"ios": "expo start --ios",

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
 	View,
 	Text,
@@ -22,13 +22,16 @@ import { useAuth } from "src/states/AuthContext";
 import InfoCircle from "@components/common/InfoCircle";
 import { getProfile, login } from "config/api";
 import * as SecureStore from "expo-secure-store";
+import { MOCK_LOGIN, MOCK_EMAIL, MOCK_PASSWORD } from "@env";
+
+const isMockLoginEnabled = MOCK_LOGIN === "true";
 
 const LoginPage = () => {
 	const navigation = useNavigation();
 
 	const loginData = ["Dife와 함께하는\n캠퍼스 라이프!", "지금 바로 시작하기"];
-	const [valueID, onChangeID] = useState("");
-	const [valuePW, onChangePW] = useState("");
+	const [valueID, setEmail] = useState("");
+	const [valuePW, setPassword] = useState("");
 	const [showPW, setShowPW] = useState(false);
 	const { updateOnboardingData } = useOnboarding();
 	const { setIsLoggedIn } = useAuth();
@@ -95,6 +98,19 @@ const LoginPage = () => {
 		}
 	};
 
+	useEffect(() => {
+		if (isMockLoginEnabled) {
+			setEmail(MOCK_EMAIL);
+			setPassword(MOCK_PASSWORD);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (isMockLoginEnabled && valueID && valuePW) {
+			handleLogin();
+		}
+	}, [valueID, valuePW]);
+
 	return (
 		<TouchableWithoutFeedback onPress={handleKeyboard}>
 			<SafeAreaView style={[LoginStyles.container]}>
@@ -112,7 +128,7 @@ const LoginPage = () => {
 							: LoginStyles.textInputId
 					}
 					placeholder="이메일을 입력해주세요"
-					onChangeText={(text) => onChangeID(text)}
+					onChangeText={(text) => setEmail(text)}
 					value={valueID}
 				/>
 				<Text style={LoginStyles.textPw}>Password</Text>
@@ -127,7 +143,7 @@ const LoginPage = () => {
 								: LoginStyles.textInputPw
 						}
 						placeholder="비밀번호를 입력해주세요"
-						onChangeText={(text) => onChangePW(text)}
+						onChangeText={(text) => setPassword(text)}
 						value={valuePW}
 						secureTextEntry={!showPW}
 					/>


### PR DESCRIPTION
### 개요

- UI를 테스트할 때마다, 불필요한 로그인 과정을 거치는 것이 귀찮다. 따라서, 테스트용 세팅을 만들어준다.

### 수정사항

`LoginPage.jsx`
  - `LoginPage`에서 `MOCK_LOGIN`의 여부에 따라, `MOCK_EMAIL`과 `MOCK_PASSWORD`를 로그인 값으로 자동으로 들어가게 하여 자동 로그인을
하도록 한다.

  - `.env.local`에서 값을 가져올때는 무조건 `string` type으로 가져오기 때문에 `==="true"`의 체킹하는 값을 컴포넌트 외부에 정의하여 로그인 스킵여부를 확인한다.

  - `useEffect`를 설정하는데, 초기 실행으로는 모킹 이메일, 패스워드를 `set`하고 이 값을 바탕으로 다음 `useEffect`에서 `handleLogin`을 실행
(두개로 나눈 이유는 `valueId`와 `valuePW`가 들어왔을 때 로그인을 하도록 하기 위함이며, 불필요한 렌더링을 줄이기 위함)

`package.json`
  - 환경변수를 가져올 때 expo에서 자체 캐싱을 하기 때문에 -c 옵션을 추가(clear)

`babel.config.js`
  - 이후에 prod 환경에서는 일부 환경 변수가 필요없을 수 있으므로, undefined되는 경우 고려하여 해당 allowUndefined 옵션 삭제