### PR TITLE
feat(chat): 채팅 생성창에서 친구목록을 가져올 수 있도록 구현

### DIFF
--- a/src/components/chat/FriendList.jsx
+++ b/src/components/chat/FriendList.jsx
@@ -6,7 +6,7 @@ import IconChatProfile from "@components/chat/IconChatProfile";
 import IconSend from "@components/common/IconSend";
 import IconMenu from "@components/chat/IconMenu";
 
-const FriendList = ({ name = "name" }) => {
+const FriendList = ({ name }) => {
 	return (
 		<>
 			<TouchableOpacity style={styles.rectangle}>

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -47,6 +47,10 @@ export const changePassword = (email) => {
 	});
 };
 
+export const getMyConnects = () => {
+	return api.get("/connects");
+};
+
 export const getProfile = () => {
 	return api.get("/members/profile");
 };

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -25,7 +25,7 @@ import IconChatSetting from "@components/chat/IconChatSetting";
 import ChatBubble from "./ChatBubble/ChatBubble";
 import { useWebSocket } from "context/WebSocketContext";
 import formatKoreanTime from "util/formatTime";
-import * as SecureStore from "expo-secure-store";
+import { getMyMemberId } from "util/secureStoreUtils";
 
 const ChatRoomPage = ({ route }) => {
 	const navigation = useNavigation();
@@ -40,11 +40,11 @@ const ChatRoomPage = ({ route }) => {
 	const flatListRef = useRef(null);
 
 	useEffect(() => {
-		const getMemberId = async () => {
-			const id = await SecureStore.getItemAsync("memberId");
-			setMemberId(parseInt(id));
+		const fetchMyMemberId = async () => {
+			const myMemberId = await getMyMemberId();
+			setMemberId(myMemberId);
 		};
-		getMemberId();
+		fetchMyMemberId();
 	}, []);
 
 	useEffect(() => {

--- a/src/util/secureStoreUtils.js
+++ b/src/util/secureStoreUtils.js
@@ -1,0 +1,11 @@
+import * as SecureStore from "expo-secure-store";
+
+export const getMyMemberId = async () => {
+	try {
+		const myMemberId = await SecureStore.getItemAsync("memberId");
+		return myMemberId ? parseInt(myMemberId) : null;
+	} catch (error) {
+		console.error("본인 memberId를 로컬에서 가져올 수 없습니다.", error);
+		return null;
+	}
+};


### PR DESCRIPTION
### 개요

- 채팅 생성창에서 친구목록을 가져올 수 있도록 한다.

### 수정 사항

- `FriendList.jsx`
  - default value 삭제
- api.js
  - 현재 멤버의 커넥트 가져오는 함수 구현
- `ChatRoomPage.jsx`
  - 현재의 멤버Id와 커넥트를 가져오는 부분 `useEffect`에 구현
- `FriendListPage.jsx`
  - `filterAcceptedConnects`: 성사된 커넥트만 보여줌
  - `getOtherMemberFromConnect`: 커넥트에서 상대방의 정보를 가져옴
  - 정보를 바탕으로 친구목록을 보여줌
- `secureStoreUtils.js`
  - 본인 ID를 secure store에서 가져오는 과정이 계속 반복되어, 유틸 함수로 추출