### PR TITLE
Fix/connect home member page feedback

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -182,10 +182,10 @@ function AppContent() {
 	}
 
 	return isLoggedIn ? (
-		<WebSocketProvider>
-			<MainNavigator />
-		</WebSocketProvider>
+		// <WebSocketProvider>
+		<MainNavigator />
 	) : (
+		// </WebSocketProvider>
 		<AuthNavigator initialRoute={initialRoute} />
 	);
 }

--- a/App.jsx
+++ b/App.jsx
@@ -182,10 +182,10 @@ function AppContent() {
 	}
 
 	return isLoggedIn ? (
-		// <WebSocketProvider>
-		<MainNavigator />
+		<WebSocketProvider>
+			<MainNavigator />
+		</WebSocketProvider>
 	) : (
-		// </WebSocketProvider>
 		<AuthNavigator initialRoute={initialRoute} />
 	);
 }

--- a/src/components/ConnectRequest.js
+++ b/src/components/ConnectRequest.js
@@ -15,14 +15,26 @@ const ConnectRequest = ({
 	const [showConnectComplete, setShowConnectComplete] = useState(false);
 
 	useEffect(() => {
+		let timeoutRequest, timeoutComplete;
+
 		if (modalVisible) {
 			setShowConnectRequest(true);
 			setShowConnectComplete(false);
+
+			timeoutRequest = setTimeout(() => {
+				setShowConnectRequest(false);
+				setShowConnectComplete(true);
+			}, 2500);
+
+			timeoutComplete = setTimeout(() => {
+				setModalVisible(false);
+			}, 4500);
 		}
-		setTimeout(() => {
-			setShowConnectRequest(false);
-			setShowConnectComplete(true);
-		}, 2500);
+
+		return () => {
+			clearTimeout(timeoutRequest);
+			clearTimeout(timeoutComplete);
+		};
 	}, [modalVisible]);
 
 	const handleBackdropPress = () => {

--- a/src/components/home/HomeCardLast.jsx
+++ b/src/components/home/HomeCardLast.jsx
@@ -24,9 +24,6 @@ const HomeCardLast = () => {
 				<Text style={styles.textMoreProfile}>
 					커넥트 페이지에서{"\n"}더 많은 프로필을 탐색할 수 있어요!
 				</Text>
-				<Text style={styles.textLoadProfile}>
-					프로필 추가 로딩까지 20:00분
-				</Text>
 				<TouchableOpacity
 					style={styles.buttonAddProfile}
 					onPress={() => navigation.navigate("Connect")}
@@ -82,7 +79,7 @@ const styles = StyleSheet.create({
 		borderRadius: 12,
 		justifyContent: "center",
 		alignItems: "center",
-		marginTop: 60,
+		marginTop: 85,
 	},
 	textAddProfile: {
 		...fontButton,

--- a/src/pages/member/MemberStyles.jsx
+++ b/src/pages/member/MemberStyles.jsx
@@ -42,7 +42,7 @@ const MemberStyles = StyleSheet.create({
 	},
 	textName: {
 		fontSize: 16,
-		lineHeight: 17,
+		lineHeight: 20,
 		fontFamily: "NotoSansCJKkr-Bold",
 		color: CustomTheme.primaryPressed,
 		marginTop: 10,


### PR DESCRIPTION
### 개요
8/13 회의에서 나온 피드백 중 일부분 수정
<br>

### 수정사항
- '홈 카드에서 프로필 추가 가능'까지 20:00분 문구 지우기
- 마이페이지에서 닉네임 잘리는 문제 해결
- 커넥트 요청 완료 모달이 2초 후 자동으로 닫히도록 변경
<br>

### 테스트 화면
<img src="https://github.com/user-attachments/assets/93d18e10-852a-4f0f-847e-47f238aebc41" width="40%" height="40%">
<img src="https://github.com/user-attachments/assets/78f856a8-eb4b-4ab1-b9f8-5f26114dbc95" width="40%" height="40%">

<br><br>

현재 값이 안 들어가 있는 상태라서 상세페이지 UI가 이상하게 보이는데, 무시하셔도 되는 부분입니다!

https://github.com/user-attachments/assets/1f6e03b8-2ca0-4213-9f0b-b9aca9008815

