### PR TITLE
fix(chat): 채팅이 null인 경우에 처리해주자

### DIFF
--- a/src/context/WebSocketContext.js
+++ b/src/context/WebSocketContext.js
@@ -95,7 +95,7 @@ export const WebSocketProvider = ({ children }) => {
 		];
 
 		const initialMessages = allChatrooms.reduce((acc, chatroom) => {
-			acc[chatroom.id] = sortByIds(chatroom.chats) || [];
+			acc[chatroom.id] = sortByIds(chatroom.chats || []);
 			return acc;
 		}, {});
 


### PR DESCRIPTION
### 개요

- 기존에는 백엔드에서 채팅방의 채팅이 없으면 empty array로 보내주었는데, 이제는 null로 받아짐. 따라서 프론트엔드에서 체킹을 추가하자