### PR TITLE
feat: 알림 서비스 백엔드 연결 및 푸쉬 알림 구현

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -207,6 +207,14 @@ function AppContent() {
 		checkAccess();
 	}, []);
 
+	Notifications.setNotificationHandler({
+		handleNotification: async () => ({
+			shouldShowAlert: true,
+			shouldPlaySound: false,
+			shouldSetBadge: false,
+		}),
+	});
+
 	const [loaded] = useFonts({
 		"NotoSansCJKkr-Bold": require("@assets/fonts/NotoSansCJKkr-Bold.otf"),
 		"NotoSansCJKkr-Medium": require("@assets/fonts/NotoSansCJKkr-Medium.otf"),

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -404,6 +404,10 @@ export const createNotificationToken = (pushToken, deviceId) => {
 	});
 };
 
+export const getNotifications = () => {
+	return api.get("/notifications");
+};
+
 export const reportPost = (type, postId) => {
 	return api.post("/reports", {
 		type,

--- a/src/pages/home/NotificationPage.js
+++ b/src/pages/home/NotificationPage.js
@@ -1,38 +1,42 @@
-import React from "react";
-import { SafeAreaView, FlatList } from "react-native";
+import React, { useState, useEffect } from "react";
+import { SafeAreaView, View, FlatList } from "react-native";
+import * as SecureStore from "expo-secure-store";
+
+import NotificationStyles from "@pages/home/NotificationStyles.js";
+import { getNotifications } from "config/api";
+
 import TopBar from "@components/common/TopBar";
 import NotificationCard from "@components/notification/NotificationCard.js";
-import NotificationStyles from "@pages/home/NotificationStyles.js";
 
 const NotificationPage = () => {
-	const notificationData = [
-		{
-			id: "1",
-			icon: "chat",
-			name: "Dann",
-			context: "님이 새로 채팅을 보냈습니다. \n “Hi there!”",
-			time: "09 : 25",
-		},
-		{
-			id: "2",
-			icon: "heart",
-			name: "Dann",
-			context: "님이 “교환학생 잘가는법” 게시물에 좋아요를 눌렀습니다.",
-			time: "09 : 25",
-		},
-		{
-			id: "3",
-			icon: "connect",
-			name: "Dann",
-			context: "님이 회원님에게 커넥트 요청을 보냈습니다.",
-			time: "09 : 25",
-		},
-		{
-			id: "4",
-			name: "Dann",
-			context: "님이 새로 채팅을 보냈습니다. \n “Hi there!”",
-		},
-	];
+	const [notificationData, setNotificationData] = useState([]);
+
+	const date = (date) => {
+		if (!date) return "";
+		const datePart = date.split("T")[0];
+		const monthDay = datePart.slice(5);
+		return monthDay.replace("-", "/");
+	};
+
+	const handleNotification = async () => {
+		try {
+			const response = await getNotifications();
+			setNotificationData(response.data.reverse());
+			await SecureStore.setItemAsync(
+				"readNotificationCount",
+				response.data.length.toString(),
+			);
+		} catch (error) {
+			console.error(
+				"알림 조회 오류: ",
+				error.response ? error.response.data : error.message,
+			);
+		}
+	};
+
+	useEffect(() => {
+		handleNotification();
+	}, [notificationData]);
 
 	return (
 		<SafeAreaView
@@ -42,7 +46,20 @@ const NotificationPage = () => {
 			<FlatList
 				style={NotificationStyles.flatlist}
 				data={notificationData}
-				renderItem={({ item }) => <NotificationCard {...item} />}
+				renderItem={({ item }) => {
+					return (
+						<>
+							<NotificationCard
+								notificationId={item.id}
+								type={item.type}
+								typeId={item.typeId}
+								created={date(item.created)}
+								content={item.message}
+							/>
+							<View style={NotificationStyles.line} />
+						</>
+					);
+				}}
 				keyExtractor={(item) => item.id}
 			/>
 		</SafeAreaView>

--- a/src/pages/home/NotificationStyles.js
+++ b/src/pages/home/NotificationStyles.js
@@ -8,6 +8,12 @@ const NotificationStyles = StyleSheet.create({
 	},
 	flatlist: {
 		width: "100%",
+		marginTop: 10,
+	},
+	line: {
+		width: "100%",
+		height: 1,
+		backgroundColor: CustomTheme.bgList,
 	},
 });
 

--- a/src/pages/member/SettingPage.jsx
+++ b/src/pages/member/SettingPage.jsx
@@ -1,6 +1,16 @@
-import React, { useState } from "react";
-import { SafeAreaView, View, Text, TouchableOpacity } from "react-native";
+import React, { useState, useEffect } from "react";
+import {
+	SafeAreaView,
+	View,
+	Text,
+	TouchableOpacity,
+	Alert,
+	Platform,
+	Linking,
+	AppState,
+} from "react-native";
 import { useNavigation } from "@react-navigation/native";
+import * as Notifications from "expo-notifications";
 
 import SettingStyles from "@pages/member/SettingStyles";
 
@@ -22,8 +32,70 @@ const SettingPage = () => {
 
 	const [switchOn, setSwitchOn] = useState(false);
 
-	const handleSwitch = () => {
-		setSwitchOn(!switchOn);
+	const checkNotificationPermissions = async () => {
+		const { status } = await Notifications.getPermissionsAsync();
+		setSwitchOn(status === "granted");
+	};
+
+	useEffect(() => {
+		checkNotificationPermissions();
+	}, []);
+
+	useEffect(() => {
+		const handleAppStateChange = (nextAppState) => {
+			if (nextAppState === "active") {
+				checkNotificationPermissions();
+			}
+		};
+
+		handleAppStateChange();
+
+		const subscription = AppState.addEventListener(
+			"change",
+			handleAppStateChange,
+		);
+
+		return () => {
+			subscription.remove();
+		};
+	}, []);
+
+	const handleSwitch = async () => {
+		if (switchOn) {
+			if (Platform.OS === "ios") {
+				Alert.alert("알림", "설정에서 알림 권한을 꺼주세요.", [
+					{
+						text: "확인",
+						onPress: () => {
+							Linking.openURL("app-settings:");
+						},
+					},
+				]);
+			} else {
+				Alert.alert("알림", "설정에서 알림 권한을 꺼주세요.");
+			}
+		} else {
+			if (Platform.OS === "ios") {
+				Alert.alert("알림", "설정에서 알림 권한을 켜주세요.", [
+					{
+						text: "확인",
+						onPress: () => {
+							Linking.openURL("app-settings:");
+						},
+					},
+				]);
+			} else {
+				const { status } =
+					await Notifications.requestPermissionsAsync();
+				if (status === "granted") {
+					Alert.alert("알림", "알림 기능이 활성화되었습니다.");
+					setSwitchOn(true);
+				} else {
+					Alert.alert("알림", "알림 권한이 거부되었습니다.");
+					setSwitchOn(false);
+				}
+			}
+		}
 	};
 
 	return (


### PR DESCRIPTION
### 개요
알림 서비스 관련 기능 개발
<br>

### 수정사항
  - 알림 서비스 백엔드 연결 및 푸쉬 알림 구현

알림 서비스 관련하여, ios는 보안 및 개인정보 보호 정책 때문에 설정으로 이동시켜야 합니다! (최초 1회 제외)
그리고 안드로이드는 알림 활성화는 권한 요청 가능하나, 비활성화는 그런 기능이 없다고 합니다. 따라서 안드로이드에서 비활성화를 요청할 땐 설정으로 이동을 유도하는 메시지만 제공하였습니다.

자세한 내용은 커밋 참고 부탁드립니다!
<br>

### 테스트 화면
**알림 서비스**

https://github.com/user-attachments/assets/2b215519-2ba7-4baa-ae7f-0d7e8d9aeced

<img src="https://github.com/user-attachments/assets/971c364c-fdc8-4b9f-9b05-8154a85f4be9" width="40%" height="40%">

클릭해서 읽은 알림을 구분하고자 시각적으로 차이를 두었습니다!

<br>

**푸쉬 알림 활성화/비활성화 구현**

https://github.com/user-attachments/assets/152f7348-dad2-4161-8cbd-c150dadfe485

https://github.com/user-attachments/assets/9a4b271c-e7e5-4fd4-bb1b-e5c18da94cde

<br><br>
