### PR TITLE
fix(chat): 채팅방 생성이 안되는 오류 해결

### DIFF
--- a/src/components/chat/FriendList.jsx
+++ b/src/components/chat/FriendList.jsx
@@ -17,7 +17,7 @@ const FriendList = ({ connectId, memberId, name, imageName }) => {
 	const { chatrooms, subscribeToNewChatroom } = useWebSocket();
 
 	const isRelevantSingleChatroom = (chatroom, myMemberId, otherMemberId) => {
-		if (chatroom.chatroomType !== "SINGLE") {
+		if (chatroom.chatroom_type !== "SINGLE") {
 			return false;
 		}
 		const members = chatroom.members;


### PR DESCRIPTION
### 개요

- 백엔드에서 변수명 변경이 있었음
- chatroomType -> chatroom_type