### PR TITLE
Refactor/get chatrooms : 채팅방 가져오기 HTTP 수정

### DIFF
--- a/src/components/chat/ChatroomItem.jsx
+++ b/src/components/chat/ChatroomItem.jsx
@@ -35,7 +35,7 @@ const ChatroomItem = ({
 		(member) => member.id !== myMemberId,
 	);
 	const otherMemberProfileImageId = otherMember?.profileImg?.id;
-	const username = otherMember.username;
+	const username = otherMember?.username ?? "UNKNOWN";
 	const screenWidth = Dimensions.get("window").width;
 	const { publishMessage } = useWebSocket();
 	const [isSwiping, setIsSwiping] = useState(false);

--- a/src/components/chat/ChatroomItem.jsx
+++ b/src/components/chat/ChatroomItem.jsx
@@ -34,7 +34,7 @@ const ChatroomItem = ({
 	const otherMember = chatroomInfo.members.find(
 		(member) => member.id !== myMemberId,
 	);
-	const otherMemberProfileImageId = otherMember.profileImg?.id;
+	const otherMemberProfileImageId = otherMember?.profileImg?.id;
 	const username = otherMember.username;
 	const screenWidth = Dimensions.get("window").width;
 	const { publishMessage } = useWebSocket();

--- a/src/context/WebSocketContext.js
+++ b/src/context/WebSocketContext.js
@@ -21,40 +21,6 @@ export const WebSocketProvider = ({ children }) => {
 	const WS_URL = process.env.EXPO_PUBLIC_WS_URL;
 
 	useEffect(() => {
-		const connectWebSocket = async () => {
-			const token = await getRefreshToken();
-
-			ws.current = new Client({
-				brokerURL: WS_URL,
-				debug: (str) => {
-					console.log(str);
-				},
-				reconnectDelay: 0,
-				connectHeaders: {
-					authorization: `Bearer ${token}`,
-				},
-				onConnect: async () => {
-					const { allChatrooms } = await updateChatroomsAndMessages();
-					subscribeToChatrooms(allChatrooms, token);
-					setIsConnected(true);
-				},
-				onStompError: (frame) => {
-					console.log(
-						"Broker reported error: " + frame.headers["message"],
-					);
-					console.log("Additional details: " + frame.body);
-				},
-				onWebSocketError: (error) => {
-					console.log("WebSocket error: " + error);
-				},
-				onWebSocketClose: () => {
-					console.log("WebSocket connection closed");
-				},
-			});
-
-			ws.current.activate();
-		};
-
 		connectWebSocket();
 
 		return () => {
@@ -64,6 +30,38 @@ export const WebSocketProvider = ({ children }) => {
 		};
 	}, []);
 
+	const connectWebSocket = async () => {
+		if (ws.current && ws.current.connected) return;
+
+		const token = await getRefreshToken();
+		ws.current = new Client({
+			brokerURL: WS_URL,
+			debug: (str) => console.log(str),
+			reconnectDelay: 0,
+			connectHeaders: {
+				authorization: `Bearer ${token}`,
+			},
+			onConnect: async () => {
+				const { allChatrooms } = await updateChatroomsAndMessages();
+				subscribeToChatrooms(allChatrooms, token);
+				setIsConnected(true);
+			},
+			onStompError: (frame) =>
+				console.error(
+					"Broker reported error:",
+					frame.headers["message"],
+				),
+			onWebSocketError: (error) =>
+				console.error("WebSocket error:", error),
+			onWebSocketClose: () => {
+				console.log("WebSocket connection closed");
+				setIsConnected(false);
+			},
+		});
+
+		ws.current.activate();
+	};
+
 	const updateChatroomsAndMessages = async () => {
 		const { allChatrooms, initialMessages } =
 			await getAuthorizedChatrooms();
@@ -72,29 +70,23 @@ export const WebSocketProvider = ({ children }) => {
 		return { allChatrooms, initialMessages };
 	};
 
-	const subscribeToChatrooms = (chatrooms, token) => {
+	const subscribeToChatrooms = async (chatrooms, token) => {
+		await connectWebSocket();
 		chatrooms.forEach(({ id }) => {
 			ws.current.subscribe(
 				`/sub/chatroom/${id}`,
-				(message) => {
-					handleIncomingMessage(id, message.body);
-				},
-				{
-					authorization: `Bearer ${token}`,
-				},
+				(message) => handleIncomingMessage(id, message.body),
+				{ authorization: `Bearer ${token}` },
 			);
 		});
 	};
 
-	const subscribeToNewChatroom = (chatroomId, token) => {
+	const subscribeToNewChatroom = async (chatroomId, token) => {
+		await connectWebSocket();
 		ws.current.subscribe(
 			`/sub/chatroom/${chatroomId}`,
-			(message) => {
-				handleIncomingMessage(chatroomId, message.body);
-			},
-			{
-				authorization: `Bearer ${token}`,
-			},
+			(message) => handleIncomingMessage(chatroomId, message.body),
+			{ authorization: `Bearer ${token}` },
 		);
 	};
 
@@ -129,10 +121,11 @@ export const WebSocketProvider = ({ children }) => {
 		return { allChatrooms, initialMessages };
 	};
 
-	const publishMessage = (message) => {
+	const publishMessage = async (message) => {
+		await connectWebSocket();
+
 		if (ws.current && ws.current.connected) {
 			const { token, ...messageWithoutToken } = message;
-
 			ws.current.publish({
 				destination: `/pub/chatroom/chat`,
 				headers: {

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -21,7 +21,7 @@ import { useWebSocket } from "context/WebSocketContext";
 import formatKoreanTime from "util/formatTime";
 import { getMyMemberId } from "util/secureStoreUtils";
 import { sortByIds } from "util/util";
-import { getBookmarkedByChatroomId } from "config/api";
+import { getBookmarkedByChatroomId, getChatsByChatroomId } from "config/api";
 
 import ArrowRight from "@components/common/ArrowRight";
 import ChatInputSend from "@components/chat/ChatInputSend";
@@ -41,6 +41,7 @@ const ChatRoomPage = ({ route }) => {
 	const screenWidth = Dimensions.get("window").width;
 	const menuAnim = useRef(new Animated.Value(screenWidth)).current;
 	const { messages } = useWebSocket();
+	const [initialMessages, setInitialMessages] = useState([]);
 	const { chatroomInfo } = route.params;
 	const [memberId, setMemberId] = useState(null);
 	const members = sortByIds(chatroomInfo.members);
@@ -83,11 +84,31 @@ const ChatRoomPage = ({ route }) => {
 			flatListRef.current.scrollToEnd({ animated: true });
 		}
 	};
+
+	useEffect(() => {
+		const fetchChatroomMessages = async () => {
+			try {
+				const response = await getChatsByChatroomId(chatroomInfo.id);
+				const messages = response.data;
+				console.log(messages);
+				setInitialMessages(messages);
+			} catch (error) {
+				console.error("Failed to fetch chatroom messages:", error);
+				setInitialMessages([]);
+			}
+		};
+		fetchChatroomMessages();
+	}, []);
+
 	const groupMessages = (messages) => {
 		const groupedMessages = [];
 		let currentGroup = [];
+		const messageIds = new Set();
 
 		messages.forEach((message, index) => {
+			if (messageIds.has(message.id)) return;
+			messageIds.add(message.id);
+
 			const isFirstMessage = index === 0;
 			const isDifferentUser =
 				!isFirstMessage &&
@@ -176,6 +197,13 @@ const ChatRoomPage = ({ route }) => {
 		}
 	};
 
+	const data = groupMessages([
+		...(initialMessages || []),
+		...(messages && messages[chatroomInfo.id]
+			? messages[chatroomInfo.id]
+			: []),
+	]);
+
 	return (
 		<SafeAreaView style={ChatRoomStyles.container}>
 			<View style={ChatRoomStyles.containerTopBar}>
@@ -201,7 +229,7 @@ const ChatRoomPage = ({ route }) => {
 			<View style={ChatRoomStyles.containerChat}>
 				<FlatList
 					ref={flatListRef}
-					data={groupMessages(messages[chatroomInfo.id] || [])}
+					data={data}
 					keyExtractor={(item, index) => index.toString()}
 					renderItem={({ item }) => (
 						<>

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -236,7 +236,7 @@ const ChatRoomPage = ({ route }) => {
 								return (
 									<ChatBubble
 										key={msg.id}
-										fileId={otherMember.profileImg?.id}
+										fileId={otherMember?.profileImg?.id}
 										username={msg.member.username}
 										message={msg.message}
 										time={formatKoreanTime(msg.created)}

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -90,7 +90,6 @@ const ChatRoomPage = ({ route }) => {
 			try {
 				const response = await getChatsByChatroomId(chatroomInfo.id);
 				const messages = response.data;
-				console.log(messages);
 				setInitialMessages(messages);
 			} catch (error) {
 				console.error("Failed to fetch chatroom messages:", error);

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -28,6 +28,7 @@ import IconChatPlus from "@components/chat/IconChatPlus";
 import ChatroomItem from "@components/chat/ChatroomItem";
 import ArrowRight from "@components/common/ArrowRight";
 import IconSearchFail from "@components/common/IconSearchFail";
+import { useWebSocket } from "context/WebSocketContext";
 
 const ChattingPage = () => {
 	const { t } = useTranslation();
@@ -40,6 +41,7 @@ const ChattingPage = () => {
 	const [searchData, setSearchData] = useState("");
 	const [searchFail, setSearchFail] = useState(false);
 	const [isSearching, setIsSearching] = useState(false);
+	const { messages } = useWebSocket();
 
 	const [isIndividualTab, setIsIndividualTab] = useState(true);
 
@@ -112,6 +114,12 @@ const ChattingPage = () => {
 
 	const data = searchData ? searchData : singleChatRoomList;
 
+	const getLatestMessage = (chatroomId) => {
+		return (
+			messages[chatroomId][messages[chatroomId].length - 1].message || ""
+		);
+	};
+
 	const renderCommunity = () => (
 		<View style={ChattingStyles.containerChatItems}>
 			<View style={ChattingStyles.flatlist}>
@@ -124,7 +132,7 @@ const ChattingPage = () => {
 							chatroomInfo={item}
 							myMemberId={myMemberId}
 							name={item.name || "Unknown"}
-							context={item.lastChat || ""}
+							context={getLatestMessage(item.id)}
 							time={formatKoreanTime(item.created)}
 						/>
 					)}

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -15,10 +15,10 @@ import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
 
 import ChattingStyles from "@pages/chat/ChattingStyles";
-import { useWebSocket } from "context/WebSocketContext";
 import { getMyMemberId } from "util/secureStoreUtils";
 import formatKoreanTime from "util/formatTime";
 import { getChatroomSearch } from "config/api";
+import { getChatroomsByType } from "config/api";
 
 import ConnectTop from "@components/connect/ConnectTop";
 import ConnectSearchIcon from "@components/connect/ConnectSearchIcon";
@@ -34,24 +34,20 @@ const ChattingPage = () => {
 	const navigation = useNavigation();
 
 	const [myMemberId, setMyMemberId] = useState(null);
-	const { chatrooms, messages, updateChatroomsAndMessages } = useWebSocket();
-
+	const [searchChatRoomList, setSearchChatroomList] = useState([]);
+	const [singleChatRoomList, setSingleChatRoomList] = useState([]);
 	const [searchTerm, setSearchTerm] = useState("");
-	const [searchData, setSearchData] = useState(null);
+	const [searchData, setSearchData] = useState("");
 	const [searchFail, setSearchFail] = useState(false);
 	const [isSearching, setIsSearching] = useState(false);
 
-	const getLatestChatByChatroomId = (id) => {
-		const chats = messages[id] || [];
-		return chats.length ? chats[chats.length - 1].message : "";
-	};
-
-	const [isIndividualTab] = useState(false);
+	const [isIndividualTab, setIsIndividualTab] = useState(true);
 
 	const handleSearch = async () => {
 		try {
 			const response = await getChatroomSearch(searchTerm);
 			setSearchData(response.data);
+			setSearchChatroomList(response.data);
 		} catch (error) {
 			Sentry.captureException(error);
 			console.error(
@@ -90,38 +86,49 @@ const ChattingPage = () => {
 		fetchMyMemberId();
 	}, []);
 
+	const fetchSingleChatroomList = async () => {
+		try {
+			const response = await getChatroomsByType("SINGLE");
+			setSingleChatRoomList(response.data);
+
+			if (response.data.length === 0) {
+				setIsIndividualTab(false);
+			} else {
+				setIsIndividualTab(true);
+			}
+		} catch (error) {
+			console.error("Failed to fetch single chatrooms:", error);
+		}
+	};
+
 	useFocusEffect(
 		useCallback(() => {
-			updateChatroomsAndMessages();
+			fetchSingleChatroomList();
 		}, []),
 	);
 
 	const { height: screenHeight } = Dimensions.get("window");
 	const isSmallScreen = screenHeight < 700;
 
-	const data = searchData ? searchData : chatrooms;
-
-	const onCompleteExit = () => {
-		updateChatroomsAndMessages();
-	};
+	const data = searchData ? searchData : singleChatRoomList;
 
 	const renderCommunity = () => (
 		<View style={ChattingStyles.containerChatItems}>
 			<View style={ChattingStyles.flatlist}>
 				<FlatList
 					contentContainerStyle={ChattingStyles.flatlistContent}
+					keyExtractor={(item) => item.id}
 					data={data}
 					renderItem={({ item }) => (
 						<ChatroomItem
 							chatroomInfo={item}
 							myMemberId={myMemberId}
-							name={item.name}
-							context={getLatestChatByChatroomId(item.id)}
+							name={item.name || "Unknown"}
+							context={item.lastChat || ""}
 							time={formatKoreanTime(item.created)}
-							onCompleteExit={onCompleteExit}
 						/>
 					)}
-					keyExtractor={(item) => item.id}
+					onEndReachedThreshold={0.1}
 				/>
 			</View>
 		</View>
@@ -198,10 +205,9 @@ const ChattingPage = () => {
 				>
 					<IconChatPlus />
 				</TouchableOpacity>
-
 				{isIndividualTab ? (
-					<></>
-				) : chatrooms.length ? (
+					<>{renderCommunity()}</>
+				) : searchChatRoomList.length ? (
 					searchFail ? (
 						<View style={ChattingStyles.containerFail}>
 							<IconSearchFail />

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -29,6 +29,7 @@ import ChatroomItem from "@components/chat/ChatroomItem";
 import ArrowRight from "@components/common/ArrowRight";
 import IconSearchFail from "@components/common/IconSearchFail";
 import { useWebSocket } from "context/WebSocketContext";
+import { getRefreshToken } from "util/secureStoreUtils";
 
 const ChattingPage = () => {
 	const { t } = useTranslation();
@@ -41,9 +42,9 @@ const ChattingPage = () => {
 	const [searchData, setSearchData] = useState("");
 	const [searchFail, setSearchFail] = useState(false);
 	const [isSearching, setIsSearching] = useState(false);
-	const { messages } = useWebSocket();
-
+	const { messages, subscribeToNewChatroom } = useWebSocket();
 	const [isIndividualTab, setIsIndividualTab] = useState(true);
+	const [token, setToken] = useState(null);
 
 	const handleSearch = async () => {
 		try {
@@ -84,11 +85,14 @@ const ChattingPage = () => {
 		const fetchMyMemberId = async () => {
 			const myMemberId = await getMyMemberId();
 			setMyMemberId(myMemberId);
+
+			const token = await getRefreshToken();
+			setToken(token);
 		};
 		fetchMyMemberId();
 	}, []);
 
-	const fetchSingleChatroomList = async () => {
+	const fetchSingleChatroomList = useCallback(async () => {
 		try {
 			const response = await getChatroomsByType("SINGLE");
 			setSingleChatRoomList(response.data);
@@ -101,12 +105,12 @@ const ChattingPage = () => {
 		} catch (error) {
 			console.error("Failed to fetch single chatrooms:", error);
 		}
-	};
+	}, []);
 
 	useFocusEffect(
 		useCallback(() => {
 			fetchSingleChatroomList();
-		}, []),
+		}, [fetchSingleChatroomList]),
 	);
 
 	const { height: screenHeight } = Dimensions.get("window");
@@ -114,12 +118,15 @@ const ChattingPage = () => {
 
 	const data = searchData ? searchData : singleChatRoomList;
 
-	const getLatestMessage = (chatroomId) => {
+	const getLatestMessage = (chatroomId, content) => {
+		if (!messages[chatroomId] || messages[chatroomId]?.length == 0) {
+			subscribeToNewChatroom(chatroomId, token);
+			return content;
+		}
 		return (
 			messages[chatroomId][messages[chatroomId].length - 1].message || ""
 		);
 	};
-
 	const renderCommunity = () => (
 		<View style={ChattingStyles.containerChatItems}>
 			<View style={ChattingStyles.flatlist}>
@@ -132,7 +139,7 @@ const ChattingPage = () => {
 							chatroomInfo={item}
 							myMemberId={myMemberId}
 							name={item.name || "Unknown"}
-							context={getLatestMessage(item.id)}
+							context={getLatestMessage(item.id, item.lastChat)}
 							time={formatKoreanTime(item.created)}
 						/>
 					)}

--- a/src/pages/chat/ChattingStyles.jsx
+++ b/src/pages/chat/ChattingStyles.jsx
@@ -110,7 +110,7 @@ const ChattingStyles = StyleSheet.create({
 		width: "100%",
 	},
 	flatlistContent: {
-		alignItems: "center",
+		// alignItems: "center",
 	},
 	containerChatItems: {
 		flex: 1,


### PR DESCRIPTION
### 개요
- 기존 채팅방 같은 경우에는 채팅방 목록을 웹소켓 연결로 불러왔었는데 제대로 fetch가 되지 않는 문제가 있었음 -> 이를 HTTP 요청으로 수정함
- 다만 최신 채팅 같은 경우에는 웹소켓으로 받아온 messages를 전달함
- 다만 최신 채팅 (messages from websocket)이 존재하지 않는 경우가 있었는데 이는 내가 만든 채팅방이 아닌 경우, 즉 상대방이 만든 채팅방일 경우에 해당 채팅방을 subscribe하지 못해서 발생한 문제로 판단함 
- 때문에 해당 경우에는 채팅방 목록에서 웹소켓을 통해 가져오는 messages를 확인 후에 없다면 채팅을 가져오는 HTTP 요청으로 해결하고자 함

---
### 채팅 탭 (ChattimgPage)
- 채팅방 목록 List : HTTP
- 내부 최신 댓글 : websocket (websocket 으로 연결된 messages가 비어있다면 해당 채팅방에 subscribe 요청)  
<img src="https://github.com/user-attachments/assets/11335128-a13d-4e5e-90b7-732a36480492" alt="채팅 탭" width="300" />

### 채팅방 내부 (ChatroomPage)
- 웹소켓 연결 채팅들이 존재하지 않는다면? -> HTTP 채팅방별 채팅 리스트 가져오기 요청 후 채팅에 합체
- Active 채팅 : websocket
- 채팅들은 테스트 하는 도중 겹치는 경우가 발생해 groupMessages에서 set 처리를 통해 중복 생성 방지를 진행했습니다.
<img src="https://github.com/user-attachments/assets/a7c080d0-9be7-46fb-8cc3-f6007c03729c" alt="채팅 탭" width="300" />

