### PR TITLE
fix/connect-scroll-1: 커넥트 스크롤 가능하도록

### DIFF
--- a/src/components/common/BottomTwoButtons.jsx
+++ b/src/components/common/BottomTwoButtons.jsx
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
 	rectangle: {
 		flexDirection: "row",
 		width: "100%",
-		height: 72,
+		height: 92,
 		alignItems: "center",
 		justifyContent: "center",
 		backgroundColor: CustomTheme.bgBasic,
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
 	rectangleShadow: {
 		flexDirection: "row",
 		width: "100%",
-		height: 72,
+		height: 92,
 		alignItems: "center",
 		justifyContent: "center",
 		backgroundColor: CustomTheme.bgBasic,
@@ -62,7 +62,8 @@ const styles = StyleSheet.create({
 		borderRadius: 27,
 		marginLeft: 24,
 		marginRight: 8,
-		marginVertical: 14,
+		marginVertical: 0,
+		marginBottom: 14,
 	},
 	button2: {
 		width: 156,
@@ -75,17 +76,17 @@ const styles = StyleSheet.create({
 		borderRadius: 27,
 		marginRight: 24,
 		marginLeft: 8,
-		marginVertical: 14,
+		marginBottom: 14,
 	},
 	text1: {
 		...fontSub16,
 		color: CustomTheme.primaryMedium,
-		paddingVertical: 10,
+		paddingVertical: 9,
 	},
 	text2: {
 		...fontSub16,
 		color: CustomTheme.bgBasic,
-		paddingVertical: 10,
+		paddingVertical: 9,
 	},
 	buttonDisabled: {
 		backgroundColor: CustomTheme.borderColor,

--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -396,7 +396,7 @@ const ChatRoomPage = ({ route }) => {
 				</Animated.View>
 			</SafeAreaView>
 			<KeyboardAvoidingView
-				style={{ marginBottom: 20 }}
+				style={{ marginBottom: 0 }}
 				behavior="padding"
 				keyboardVerticalOffset={statusBarHeight - 50}
 				onContentSizeChange={handleContentSizeChange}
@@ -407,6 +407,7 @@ const ChatRoomPage = ({ route }) => {
 				/>
 			</KeyboardAvoidingView>
 			<View style={ChatRoomStyles.chatInput} />
+			<View style={ChatRoomStyles.chatInputBottom} />
 		</>
 	);
 };

--- a/src/pages/chat/ChatRoomStyles.jsx
+++ b/src/pages/chat/ChatRoomStyles.jsx
@@ -112,6 +112,10 @@ const ChatRoomStyles = StyleSheet.create({
 	chatInput: {
 		backgroundColor: CustomTheme.bgBasic,
 	},
+	chatInputBottom: {
+		height: 34,
+		backgroundColor: "white",
+	},
 });
 
 export default ChatRoomStyles;

--- a/src/pages/connect/ConnectPage.js
+++ b/src/pages/connect/ConnectPage.js
@@ -134,12 +134,14 @@ const ConnectPage = () => {
 	const isSmallScreen = screenHeight < 700;
 
 	return (
-		<TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
-			<SafeAreaView style={ConnectStyles.container}>
-				<View style={ConnectStyles.backgroundBlue} />
-				<View style={ConnectStyles.connectTop}>
-					<ConnectTop />
-				</View>
+		<SafeAreaView style={ConnectStyles.container}>
+			<View style={ConnectStyles.backgroundBlue} />
+
+			<View style={ConnectStyles.connectTop}>
+				<ConnectTop />
+			</View>
+
+			<TouchableWithoutFeedback onPress={Keyboard.dismiss}>
 				<View
 					style={[
 						ConnectStyles.textIconContainer,
@@ -154,123 +156,127 @@ const ConnectPage = () => {
 						onPress={() => navigation.navigate("LikeUserOneToOne")}
 					/>
 				</View>
-				<View
-					style={[
-						ConnectStyles.searchContainer,
-						isSmallScreen && { top: -25 },
-					]}
-				>
-					<TouchableOpacity onPress={pressButton}>
-						<FilterIcon style={ConnectStyles.searchFilter} />
-						{totalSelection > 0 && (
-							<View style={ConnectStyles.containerImageNumber}>
-								<IconCircleNumber
-									style={ConnectStyles.iconCircleNumber}
-									color={CustomTheme.bgBasic}
-								/>
-								<Text style={ConnectStyles.textImageNumber}>
-									{totalSelection}
-								</Text>
-							</View>
-						)}
-					</TouchableOpacity>
-					<FilterBottomSlide
-						modalVisible={modalVisible}
-						setModalVisible={setModalVisible}
-						onFilterResponse={handleFilterResponse}
-						onSearchResponse={handleFilterSearchFail}
-						onTotalSelection={handleTotalSelection}
-						isReset={isReset}
+			</TouchableWithoutFeedback>
+			<View
+				style={[
+					ConnectStyles.searchContainer,
+					isSmallScreen && { top: -25 },
+				]}
+			>
+				<TouchableOpacity onPress={pressButton}>
+					<FilterIcon style={ConnectStyles.searchFilter} />
+					{totalSelection > 0 && (
+						<View style={ConnectStyles.containerImageNumber}>
+							<IconCircleNumber
+								style={ConnectStyles.iconCircleNumber}
+								color={CustomTheme.bgBasic}
+							/>
+							<Text style={ConnectStyles.textImageNumber}>
+								{totalSelection}
+							</Text>
+						</View>
+					)}
+				</TouchableOpacity>
+				<FilterBottomSlide
+					modalVisible={modalVisible}
+					setModalVisible={setModalVisible}
+					onFilterResponse={handleFilterResponse}
+					onSearchResponse={handleFilterSearchFail}
+					onTotalSelection={handleTotalSelection}
+					isReset={isReset}
+				/>
+				<View style={ConnectStyles.searchIconContainer}>
+					<TextInput
+						style={[
+							ConnectStyles.search,
+							(searchFail ||
+								(searchData && searchData.length > 0)) && {
+								paddingLeft: 40,
+							},
+						]}
+						placeholder={t("searchPlaceholder")}
+						value={searchTerm}
+						onChangeText={setSearchTerm}
+						onFocus={handleFocus}
+						onBlur={handleBlur}
+						onSubmitEditing={handleSearch}
 					/>
-					<View style={ConnectStyles.searchIconContainer}>
-						<TextInput
-							style={[
-								ConnectStyles.search,
-								(searchFail ||
-									(searchData && searchData.length > 0)) && {
-									paddingLeft: 40,
-								},
-							]}
-							placeholder={t("searchPlaceholder")}
-							value={searchTerm}
-							onChangeText={setSearchTerm}
-							onFocus={handleFocus}
-							onBlur={handleBlur}
-							onSubmitEditing={handleSearch}
+					{(searchFail || (searchData && searchData.length > 0)) && (
+						<TouchableOpacity
+							style={ConnectStyles.iconArrowRightSearch}
+							onPress={handleSearchBack}
+						>
+							<ArrowRight color="#B0D0FF" />
+						</TouchableOpacity>
+					)}
+					{isSearching ? (
+						<ConnectSearchCancel
+							style={ConnectStyles.searchIcon}
+							onPress={handleCancel}
 						/>
-						{(searchFail ||
-							(searchData && searchData.length > 0)) && (
-							<TouchableOpacity
-								style={ConnectStyles.iconArrowRightSearch}
-								onPress={handleSearchBack}
-							>
-								<ArrowRight color="#B0D0FF" />
-							</TouchableOpacity>
-						)}
-						{isSearching ? (
-							<ConnectSearchCancel
-								style={ConnectStyles.searchIcon}
-								onPress={handleCancel}
-							/>
-						) : (
-							<ConnectSearchIcon
-								style={ConnectStyles.searchIcon}
-								onPress={handleSearch}
-							/>
-						)}
-					</View>
+					) : (
+						<ConnectSearchIcon
+							style={ConnectStyles.searchIcon}
+							onPress={handleSearch}
+						/>
+					)}
 				</View>
+			</View>
 
-				<View style={ConnectStyles.containerDife}>
-					<View style={ConnectStyles.connectDife}>
-						<ConnectDife />
-					</View>
+			<View style={ConnectStyles.containerDife}>
+				<View style={ConnectStyles.connectDife}>
+					<ConnectDife />
 				</View>
+			</View>
+			<TouchableWithoutFeedback onPress={Keyboard.dismiss}>
 				<View style={ConnectStyles.midContainer}>
 					<TouchableOpacity
 						style={ConnectStyles.resetContainer}
-						onPress={handleReset}
+						onPress={[handleReset]}
 					>
 						<Text style={ConnectStyles.textReset}>Reset</Text>
 						<ConnectReset />
 					</TouchableOpacity>
 				</View>
+			</TouchableWithoutFeedback>
 
-				{searchFail ? (
-					<View
-						style={[
-							ConnectStyles.cardContainer,
-							{ marginHorizontal: 25 },
-						]}
-					>
-						<ConnectCard fail="true" />
+			{searchFail ? (
+				<View
+					style={[
+						ConnectStyles.cardContainer,
+						{ marginHorizontal: 25 },
+					]}
+				>
+					<ConnectCard fail="true" />
+				</View>
+			) : (
+				<View style={ConnectStyles.cardContainer}>
+					<View style={ConnectStyles.flatlist}>
+						<FlatList
+							scrollEnabled={true}
+							keyboardShouldPersistTaps="handled"
+							contentContainerStyle={[
+								ConnectStyles.flatlistContent,
+								{ minHeight: "100%" },
+							]}
+							data={
+								searchData === null
+									? profileDataList
+									: searchData
+							}
+							renderItem={({ item }) => (
+								<ConnectCard
+									{...item}
+									tags={item.tags}
+									fileId={item.profileImg?.id}
+								/>
+							)}
+							keyExtractor={(item) => item.id}
+						/>
 					</View>
-				) : (
-					<View style={ConnectStyles.cardContainer}>
-						<View style={ConnectStyles.flatlist}>
-							<FlatList
-								contentContainerStyle={
-									ConnectStyles.flatlistContent
-								}
-								data={
-									searchData === null
-										? profileDataList
-										: searchData
-								}
-								renderItem={({ item }) => (
-									<ConnectCard
-										{...item}
-										tags={item.tags}
-										fileId={item.profileImg?.id}
-									/>
-								)}
-								keyExtractor={(item) => item.id}
-							/>
-						</View>
-					</View>
-				)}
-			</SafeAreaView>
-		</TouchableWithoutFeedback>
+				</View>
+			)}
+		</SafeAreaView>
 	);
 };
 


### PR DESCRIPTION
### 개요

- 이전에 사용되었던 빈화면 클릭시 키보드를 내려가기 위한 용도였던 TouchableWithoutFeedback은 View 단위로 감싸 사용했어야 했음
- "빈화면"의 범위에 TouchableWithoutFeedback 을 감싸 이전 구현 방향을 이어나감
- TouchableWithoutFeedback과 FlatList의 겹침 현상으로 인해 스크롤이 되지 않았던 문제 해결

---

### 테스트 화면 
파란색 탑 -> 커넥트 카드 사이 -> Reset 버튼 옆 빈 공간 클릭


https://github.com/user-attachments/assets/a693a2d3-39e2-4de0-9f7c-a88fdc39b844

