### PR TITLE
chore(home): 홈 화면과 커넥트 화면에서 유저 리스트 유지

### DIFF
--- a/src/pages/connect/ConnectPage.js
+++ b/src/pages/connect/ConnectPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
 	View,
 	Text,
@@ -35,10 +35,11 @@ const ConnectPage = () => {
 	const { t } = useTranslation();
 	const navigation = useNavigation();
 
+	const isInitialMount = useRef(true);
 	const [profileDataList, setProfileDataList] = useState([]);
 	const RANDOM_MEMBER_COUNT = 10;
 
-	const cardProfiles = async () => {
+	const fetchCardProfiles = async () => {
 		try {
 			const response = await getRandomMembersByCount(RANDOM_MEMBER_COUNT);
 			const updatedData = formatProfileData(response.data);
@@ -55,9 +56,14 @@ const ConnectPage = () => {
 		}
 	};
 
-	useEffect(() => {
-		cardProfiles();
-	}, []);
+	useFocusEffect(
+		useCallback(() => {
+			if (isInitialMount.current) {
+				fetchCardProfiles();
+				isInitialMount.current = false;
+			}
+		}, []),
+	);
 
 	const [searchTerm, setSearchTerm] = useState("");
 	const [searchData, setSearchData] = useState(null);
@@ -117,7 +123,7 @@ const ConnectPage = () => {
 	const [isReset, setIsReset] = useState(false);
 
 	const handleReset = () => {
-		cardProfiles();
+		fetchCardProfiles();
 		setTotalSelection(null);
 		setIsReset(!isReset);
 	};

--- a/src/pages/connect/ConnectPage.js
+++ b/src/pages/connect/ConnectPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from "react";
+import React, { useState, useCallback, useRef, useFocusEffect } from "react";
 import {
 	View,
 	Text,

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import { LinearGradient } from "expo-linear-gradient";
 import {
 	View,
@@ -39,12 +39,13 @@ const HomePage = () => {
 	const { t } = useTranslation();
 	const navigation = useNavigation();
 
+	const isInitialMount = useRef(true);
 	const [profileDataList, setProfileDataList] = useState([]);
 	const [notificationNumber, setNotificationNumber] = useState(0);
 
 	const RANDOM_MEMBER_COUNT = 10;
 
-	const homeProfile = async () => {
+	const fetchProfileQueue = async () => {
 		try {
 			const response = await getRandomMembersByCount(RANDOM_MEMBER_COUNT);
 			const updatedData = formatProfileData(response.data);
@@ -87,8 +88,11 @@ const HomePage = () => {
 
 	useFocusEffect(
 		useCallback(() => {
+			if (isInitialMount.current) {
+				fetchProfileQueue();
+				isInitialMount.current = false;
+			}
 			getNotificationNumber();
-			homeProfile();
 		}, []),
 	);
 


### PR DESCRIPTION
### 개요

- 홈과 커넥트 화면에서 유저의 목록이 새로 매번 바뀐다.

### 수정사항

- 기존 useFocusEffect와 useCallback의 조합은 그대로 놔두고(notification fetch와 같은 기능 때문에) useRef를 활용한 플래깅 기능을 추가해서 앱을 껐다
키는 경우에만 새로 fetch 하도록 추가한다.