### PR TITLE
Fix/beta test feedback 2: 1차 베타테스트 피드백 관련 수정2

### DIFF
--- a/src/components/common/Preparing.jsx
+++ b/src/components/common/Preparing.jsx
@@ -4,7 +4,7 @@ import Svg, { Path } from "react-native-svg";
 const Preparing = (props) => (
 	<Svg
 		xmlns="http://www.w3.org/2000/svg"
-		width={401}
+		width="100%"
 		height={841}
 		fill="none"
 		{...props}

--- a/src/components/community/IconProfileBackground.jsx
+++ b/src/components/community/IconProfileBackground.jsx
@@ -1,7 +1,12 @@
 import * as React from "react";
-import Svg, { Circle } from "react-native-svg";
+import Svg, {
+	Circle,
+	Defs,
+	ClipPath,
+	Image as SvgImage,
+} from "react-native-svg";
 
-const IconProfileBackground = (props) => (
+const IconProfileBackground = ({ profileImage, ...props }) => (
 	<Svg
 		xmlns="http://www.w3.org/2000/svg"
 		width={36}
@@ -9,7 +14,23 @@ const IconProfileBackground = (props) => (
 		fill="none"
 		{...props}
 	>
+		<Defs>
+			<ClipPath id="clip">
+				<Circle cx={18} cy={18} r={18} />
+			</ClipPath>
+		</Defs>
 		<Circle cx={18} cy={18} r={18} fill="#B0D0FF" />
+		{profileImage && (
+			<SvgImage
+				x={0}
+				y={0}
+				width={36}
+				height={36}
+				preserveAspectRatio="xMidYMid slice"
+				href={{ uri: profileImage }}
+				clipPath="url(#clip)"
+			/>
+		)}
 	</Svg>
 );
 export default IconProfileBackground;

--- a/src/pages/community/PostPage.jsx
+++ b/src/pages/community/PostPage.jsx
@@ -81,6 +81,7 @@ const PostPage = ({ route }) => {
 	const [isTranslation, setIsTranslation] = useState(false);
 	const [translationCount, setTranslationCount] = useState();
 	const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+	const [profilePresignUrl, setProfilePresignUrl] = useState(null);
 
 	const commentRef = useRef(null);
 	const scrollViewRef = useRef(null);
@@ -123,6 +124,12 @@ const PostPage = ({ route }) => {
 
 			if (postByIdResponse.data.isPublic === false) {
 				setWriterName(postByIdResponse.data.writer.username);
+				if (postByIdResponse.data.writer.profileImg.id) {
+					const presignUrl = await getProfileImageByFileId(
+						postByIdResponse.data.writer.profileImg.id,
+					);
+					setProfilePresignUrl(presignUrl.data);
+				}
 			} else if (postByIdResponse.data.isPublic === true) {
 				setWriterName(t("anonymousCheckboxLabel"));
 			}
@@ -420,10 +427,14 @@ const PostPage = ({ route }) => {
 					<View style={PostStyles.containerWriterRow}>
 						<View style={{ flexDirection: "row" }}>
 							<View style={PostStyles.containerProfile}>
-								<IconProfileBackground />
-								<IconProfileUser24
-									style={PostStyles.iconProfileUser24}
+								<IconProfileBackground
+									profileImage={profilePresignUrl}
 								/>
+								{profilePresignUrl ? null : (
+									<IconProfileUser24
+										style={PostStyles.iconProfileUser24}
+									/>
+								)}
 							</View>
 							<View style={PostStyles.containerWriterText}>
 								<Text style={PostStyles.textWriter}>

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -33,7 +33,6 @@ import IconNotSeePw from "@components/login/IconNotSeePw";
 import IconSeePw from "@components/login/IconSeePw";
 import DifeLine from "@components/common/DifeLine";
 import InfoCircle from "@components/common/InfoCircle";
-import * as Notifications from "expo-notifications";
 
 const isMockLoginEnabled = process.env.EXPO_PUBLIC_MOCK_LOGIN === "true";
 const mockEmail = process.env.EXPO_PUBLIC_MOCK_EMAIL || "";

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -15,12 +15,18 @@ import { useTranslation } from "react-i18next";
 import * as SecureStore from "expo-secure-store";
 import * as Sentry from "@sentry/react-native";
 import * as Notifications from "expo-notifications";
+import { getLocales } from "expo-localization";
 
 import { CustomTheme } from "@styles/CustomTheme";
 import LoginStyles from "@pages/login/LoginStyles";
 import { useOnboarding } from "src/states/OnboardingContext.js";
 import { useAuth } from "src/states/AuthContext";
-import { getMyProfile, login, createNotificationToken } from "config/api";
+import {
+	getMyProfile,
+	login,
+	createNotificationToken,
+	updateMyProfile,
+} from "config/api";
 
 import BottomTwoButtons from "@components/common/BottomTwoButtons";
 import IconNotSeePw from "@components/login/IconNotSeePw";
@@ -78,6 +84,7 @@ const LoginPage = () => {
 			const id = loginResponse.data.member_id;
 			const accessToken = loginResponse.data.accessToken;
 			const refreshToken = loginResponse.data.refreshToken;
+			const isFirstLogin = loginResponse.data.isFirstLogin;
 
 			await SecureStore.setItemAsync("memberId", JSON.stringify(id));
 			await SecureStore.setItemAsync("accessToken", accessToken);
@@ -86,6 +93,10 @@ const LoginPage = () => {
 
 			console.log(accessToken);
 			updateOnboardingData({ id, accessToken, refreshToken });
+
+			if (isFirstLogin) {
+				await updateSettingLanguage();
+			}
 
 			const profileResponse = await getMyProfile();
 			if (profileResponse.data.isVerified) {
@@ -129,6 +140,19 @@ const LoginPage = () => {
 						error.response ? error.response.data : error.message,
 					);
 			}
+		}
+	};
+
+	const updateSettingLanguage = async () => {
+		try {
+			const formData = new FormData();
+			formData.append(
+				"settingLanguage",
+				getLocales()[0].languageCode.toUpperCase(),
+			);
+			await updateMyProfile(formData);
+		} catch (error) {
+			console.error("언어 설정 업데이트 오류:", error);
 		}
 	};
 

--- a/src/pages/onboarding/CountrySelectionPage.jsx
+++ b/src/pages/onboarding/CountrySelectionPage.jsx
@@ -16,7 +16,7 @@ import {
 } from "@components/onboarding/Constants";
 
 const ItemView = ({ item, selected, action }) => {
-	let text = `${item.name} (+${item.callingCode})`;
+	let text = `${item.name}`;
 	let selectedIcon = null;
 
 	if (selected != null && selected.callingCode === item.callingCode) {


### PR DESCRIPTION
### 개요
1차 베타테스트 피드백 관련 수정2
<br>

### 수정사항
- 커뮤니티 작성자가 익명이 아닐 경우 프로필 사진 표시 기능 추가
- Preparing 페이지에서 뒤로 갈 때 이미지가 넘치는 현상 수정
- 최초 로그인 시 기기 언어를 확인하여 기본 설정 언어(setting_language) 변경

아래는 '최초 로그인 시 기기 언어를 확인하여 기본 설정 언어(setting_language) 변경' 커밋과 관련된 설명입니다!
피드백 중 영어 -> 한국어 번역이 제대로 되지 않는다는 문제가 있었는데요, 해당 오류 원인이 최초 로그인 시 기본 언어가 영어로 설정되는 데서 비롯된 문제였습니다. 그래서 최초 로그인 시 기본 설정 언어를 기기 언어로 변경(데이터베이스에 저장)하도록 수정했습니다! 따라서 사용자가 앱 내에서 설정 언어를 변경하지 않는 한, 계속해서 데이터베이스에 저장된 언어로 사용할 수 있습니다 :)

<br>

### 테스트 화면
**커뮤니티 작성자가 익명이 아닐 경우 프로필 사진 표시 기능 추가**

<img src="https://github.com/user-attachments/assets/90d87817-e150-4978-9ebe-4b43ad6a43eb" width="40%" height="40%">

<br><br>

**Preparing 페이지에서 뒤로 갈 때 이미지가 넘치는 현상 수정**

https://github.com/user-attachments/assets/710ab82e-c7c3-4d59-8847-c86aa29e1ffb

<br><br>

**최초 로그인 시 기기 언어를 확인하여 기본 설정 언어(setting_language) 변경**

<img src="https://github.com/user-attachments/assets/e2405037-848c-408e-a2c5-a7966b71fe0f" width="40%" height="40%">

<br><br>
