### PR TITLE
hotfix/request-notification-permission-1: 알림 권한 묻고 토큰 생성 안전하게

### DIFF
--- a/src/pages/login/AccessPage.js
+++ b/src/pages/login/AccessPage.js
@@ -13,7 +13,7 @@ import IconAccessNotification from "@components/login/IconAccessNotification";
 import IconAccessImage from "@components/login/IconAccessImage";
 import IconAccessPhone from "@components/login/IconAccessPhone";
 import GoBack from "@components/common/GoBack";
-import { useNotification } from 'src/contexts/NotificationContext';
+import { useNotification } from "src/contexts/NotificationContext";
 
 const AccessPage = () => {
 	const { t } = useTranslation();
@@ -24,12 +24,12 @@ const AccessPage = () => {
 		const { status: existingStatus } =
 			await Notifications.getPermissionsAsync();
 
-		if (existingStatus !== 'granted') {
+		if (existingStatus !== "granted") {
 			const { status } = await Notifications.requestPermissionsAsync();
-			setIsNotificationGranted(status === 'granted'); 
-			} else {
-			setIsNotificationGranted(true);  
-			}
+			setIsNotificationGranted(status === "granted");
+		} else {
+			setIsNotificationGranted(true);
+		}
 
 		const firstLaunch = await SecureStore.getItem("hasLaunched");
 

--- a/src/pages/login/AccessPage.js
+++ b/src/pages/login/AccessPage.js
@@ -13,18 +13,23 @@ import IconAccessNotification from "@components/login/IconAccessNotification";
 import IconAccessImage from "@components/login/IconAccessImage";
 import IconAccessPhone from "@components/login/IconAccessPhone";
 import GoBack from "@components/common/GoBack";
+import { useNotification } from 'src/contexts/NotificationContext';
 
 const AccessPage = () => {
 	const { t } = useTranslation();
 	const navigation = useNavigation();
+	const { setIsNotificationGranted } = useNotification();
 
 	const requestPermissions = async () => {
 		const { status: existingStatus } =
 			await Notifications.getPermissionsAsync();
 
-		if (existingStatus !== "granted") {
-			await Notifications.requestPermissionsAsync();
-		}
+		if (existingStatus !== 'granted') {
+			const { status } = await Notifications.requestPermissionsAsync();
+			setIsNotificationGranted(status === 'granted'); 
+			} else {
+			setIsNotificationGranted(true);  
+			}
 
 		const firstLaunch = await SecureStore.getItem("hasLaunched");
 

--- a/src/pages/login/AccessPage.js
+++ b/src/pages/login/AccessPage.js
@@ -13,22 +13,17 @@ import IconAccessNotification from "@components/login/IconAccessNotification";
 import IconAccessImage from "@components/login/IconAccessImage";
 import IconAccessPhone from "@components/login/IconAccessPhone";
 import GoBack from "@components/common/GoBack";
-import { useNotification } from "src/contexts/NotificationContext";
 
 const AccessPage = () => {
 	const { t } = useTranslation();
 	const navigation = useNavigation();
-	const { setIsNotificationGranted } = useNotification();
 
 	const requestPermissions = async () => {
 		const { status: existingStatus } =
 			await Notifications.getPermissionsAsync();
 
 		if (existingStatus !== "granted") {
-			const { status } = await Notifications.requestPermissionsAsync();
-			setIsNotificationGranted(status === "granted");
-		} else {
-			setIsNotificationGranted(true);
+			await Notifications.requestPermissionsAsync();
 		}
 
 		const firstLaunch = await SecureStore.getItem("hasLaunched");

--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -80,13 +80,23 @@ const LoginPage = () => {
 	const handleLogin = async () => {
 		try {
 			const loginResponse = await login(emailRef.val, valuePW);
-			const { status } = await Notifications.requestPermissionsAsync();
 
 			let token = "";
-			if (status === "granted") {
-				token = (await Notifications.getExpoPushTokenAsync()).data;
-			} else {
+			const { status: existingStatus } =
+				await Notifications.getPermissionsAsync();
+			let finalStatus = existingStatus;
+
+			if (existingStatus !== "granted") {
+				const { status } =
+					await Notifications.requestPermissionsAsync();
+				finalStatus = status;
+			}
+
+			if (finalStatus !== "granted") {
+				token = "undefined";
 				console.log("Push notification permissions not granted");
+			} else {
+				token = (await Notifications.getExpoPushTokenAsync()).data;
 			}
 
 			const id = loginResponse.data.member_id;
@@ -114,7 +124,9 @@ const LoginPage = () => {
 				navigation.navigate("Nickname");
 			}
 
-			await createNotificationToken(token, deviceId);
+			if (token) {
+				await createNotificationToken(token, deviceId);
+			}
 		} catch (error) {
 			Sentry.captureException(error);
 			console.error(


### PR DESCRIPTION
#207 에서 이어져온 hotfix 사항 (로그인 다운 문제)
- Permission 권한 existingStatus와 finalStatus로 확인
- AccessPage 수정 이유 : 이미 권한 동의 있는 기기에 한해서는 2차 동의를 얻지 않도록 하기 위함 