### PR TITLE
Fix/beta test feedback 4: 베타테스트 및 12/28, 1/2 회의 내용 피드백 수정사항

### DIFF
--- a/src/components/chat/Bookmark.jsx
+++ b/src/components/chat/Bookmark.jsx
@@ -11,6 +11,7 @@ import IconBookmark from "@components/chat/IconBookmark";
 import ModalNoBookmark from "@components/chat/ModalNoBookmark";
 import DashedLine from "@components/chat/DashedLine";
 import ModalTranslationsCount from "@components/common/ModalTranslationsCount";
+import LoadingDots from "@components/common/loading/LoadingDots";
 
 const { fontCaption, fontNavi } = CustomTheme;
 
@@ -25,6 +26,7 @@ const Bookmark = ({ bookmarkedId, context, created, translations }) => {
 	const [modalVisible, setModalVisible] = useState(false);
 	const [modalTranslationVisible, setModalTranslationVisible] =
 		useState(false);
+	const [translating, setTranslating] = useState(false);
 
 	const rectangleStyle = () =>
 		expanded ? styles.rectangleExpanded : styles.rectangle;
@@ -54,15 +56,19 @@ const Bookmark = ({ bookmarkedId, context, created, translations }) => {
 					if (translationCount === 0) {
 						setModalTranslationVisible(true);
 						setIsTranslation(true);
+						setTranslating(true);
 						const response =
 							await translationByBookmarkedId(bookmarkedId);
 						setContent(response.data.translations[0].text);
+						setTranslating(false);
 					} else if (translationCount <= 15) {
 						setModalTranslationVisible(false);
 						setIsTranslation(true);
+						setTranslating(true);
 						const response =
 							await translationByBookmarkedId(bookmarkedId);
 						setContent(response.data.translations[0].text);
+						setTranslating(false);
 					} else if (translationCount > 15) {
 						setModalTranslationVisible(true);
 					}
@@ -133,13 +139,19 @@ const Bookmark = ({ bookmarkedId, context, created, translations }) => {
 									{context}
 								</Text>
 							</View>
-							<TouchableOpacity onPress={handleTranslations}>
-								<Text style={styles.textTranslation}>
-									{isTranslation
-										? t("viewOriginalOnlyButton")
-										: t("translateButton")}
-								</Text>
-							</TouchableOpacity>
+
+							{translating ? (
+								<LoadingDots />
+							) : (
+								<TouchableOpacity onPress={handleTranslations}>
+									<Text style={styles.textTranslation}>
+										{isTranslation
+											? t("viewOriginalOnlyButton")
+											: t("translateButton")}
+									</Text>
+								</TouchableOpacity>
+							)}
+
 							<ModalTranslationsCount
 								modalVisible={modalTranslationVisible}
 								setModalVisible={setModalTranslationVisible}

--- a/src/components/chat/ChatroomItem.jsx
+++ b/src/components/chat/ChatroomItem.jsx
@@ -25,8 +25,8 @@ const { fontCaption, fontNavi } = CustomTheme;
 
 const ChatroomItem = ({
 	chatroomInfo,
-	context,
-	time,
+	content,
+	lastChatCreated,
 	myMemberId,
 	onCompleteExit,
 	unreadChatsCount,
@@ -131,14 +131,16 @@ const ChatroomItem = ({
 										},
 									]}
 								>
-									{context}
+									{content}
 								</Text>
 							</View>
 						</View>
 						<View
 							style={{ alignItems: "flex-end", marginRight: 25 }}
 						>
-							<Text style={styles.textTime}>{time}</Text>
+							<Text style={styles.textTime}>
+								{lastChatCreated}
+							</Text>
 							{unreadChatsCount > 0 && (
 								<View style={styles.containerUnreadChatsCount}>
 									<Text style={styles.textUnreadChatsCount}>

--- a/src/components/chat/IconChatProfile.jsx
+++ b/src/components/chat/IconChatProfile.jsx
@@ -73,7 +73,7 @@ const IconChatProfile = ({ size = 48, fileId, ...props }) => {
 				<View
 					style={[
 						styles.fallbackContainer,
-						{ top: size * 0.25, left: size * 0.125 },
+						{ top: size * 0.18, left: size * 0.125 },
 					]}
 				>
 					{size <= 36 ? <IconProfileUser24 /> : <IconProfileUser32 />}

--- a/src/components/common/loading/LoadingDots.jsx
+++ b/src/components/common/loading/LoadingDots.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef } from "react";
+import { View, Animated, StyleSheet, SafeAreaView } from "react-native";
+
+const INITAL_OPACITY = 0.2;
+const DOT_COUNT = 3;
+
+const createAnimatedValues = (count, initialValue) => {
+	const animatedValues = [];
+	for (let i = 0; i < count; i++) {
+		animatedValues.push(new Animated.Value(initialValue));
+	}
+	return animatedValues;
+};
+
+const Dot = ({ opacity, translateY }) => {
+	return (
+		<Animated.View
+			style={[
+				styles.dot,
+				{
+					opacity,
+					transform: [{ translateY }],
+				},
+			]}
+		/>
+	);
+};
+
+const LoadingDots = () => {
+	const dotOpacities = useRef(
+		createAnimatedValues(DOT_COUNT, INITAL_OPACITY),
+	).current;
+
+	const createAnimationConfig = (isOn) => {
+		return {
+			toValue: isOn ? 1 : INITAL_OPACITY,
+			duration: 500,
+			useNativeDriver: true,
+		};
+	};
+
+	const createSequence = (animatedValue) => {
+		return Animated.sequence([
+			Animated.timing(animatedValue, createAnimationConfig(true)),
+			Animated.timing(animatedValue, createAnimationConfig(false)),
+		]);
+	};
+
+	useEffect(() => {
+		const animate = () => {
+			Animated.loop(
+				Animated.stagger(400, dotOpacities.map(createSequence)),
+			).start();
+		};
+		animate();
+	}, [dotOpacities]);
+
+	return (
+		<SafeAreaView style={{ flex: 1 }}>
+			<View style={styles.dots}>
+				{dotOpacities.map((opacity, index) => (
+					<Dot
+						key={index}
+						opacity={opacity}
+						translateY={opacity.interpolate({
+							inputRange: [0, 1],
+							outputRange: [0, -6],
+						})}
+					/>
+				))}
+			</View>
+		</SafeAreaView>
+	);
+};
+
+const styles = StyleSheet.create({
+	dot: {
+		width: 6.16,
+		height: 6.16,
+		borderRadius: 10,
+		backgroundColor: "#2964E0",
+		marginHorizontal: 3,
+	},
+	dots: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "center",
+	},
+});
+
+export default LoadingDots;

--- a/src/components/community/ItemComment.jsx
+++ b/src/components/community/ItemComment.jsx
@@ -25,6 +25,7 @@ import IconComment from "@components/community/IconComment";
 import IconReply from "@components/community/IconReply";
 import ModalKebabMenu from "@components/community/ModalKebabMenu";
 import ModalTranslationsCount from "@components/common/ModalTranslationsCount";
+import LoadingDots from "@components/common/loading/LoadingDots";
 
 const { fontCaption, fontNavi } = CustomTheme;
 
@@ -44,6 +45,7 @@ const ItemComment = ({ commentList = [], onReply }) => {
 		useState(false);
 	const [translationCount, setTranslationCount] = useState();
 	const [focusParentComment, setFocusParentComment] = useState(null);
+	const [translating, setTranslating] = useState({});
 
 	useEffect(() => {
 		const newHeartStates = commentList.map((post) => ({
@@ -84,6 +86,8 @@ const ItemComment = ({ commentList = [], onReply }) => {
 		if (isComment && translations[commentId]) return;
 		if (!isComment && replyTranslations[commentId]) return;
 
+		setTranslating((prev) => ({ ...prev, [commentId]: true }));
+
 		try {
 			const responseCount = await getMyProfile();
 			const count =
@@ -121,6 +125,8 @@ const ItemComment = ({ commentList = [], onReply }) => {
 				"댓글 번역 오류:",
 				error.response ? error.response.data : error.message,
 			);
+		} finally {
+			setTranslating((prev) => ({ ...prev, [commentId]: false }));
 		}
 	};
 
@@ -367,19 +373,27 @@ const ItemComment = ({ commentList = [], onReply }) => {
 								position={modalPosition}
 							/>
 						)}
-						<TouchableOpacity
-							style={styles.textTranslation}
-							onPress={() => {
-								handleTranslate(comment.id, true);
-								handleToggleTranslation(comment.id, true);
-							}}
-						>
-							<Text style={styles.textTranslation}>
-								{showTranslations[comment.id]
-									? t("viewOriginalButton")
-									: t("translateButton")}
-							</Text>
-						</TouchableOpacity>
+
+						{translating[comment.id] ? (
+							<View style={styles.textTranslation}>
+								<LoadingDots />
+							</View>
+						) : (
+							<TouchableOpacity
+								style={styles.textTranslation}
+								onPress={() => {
+									handleTranslate(comment.id, true);
+									handleToggleTranslation(comment.id, true);
+								}}
+							>
+								<Text style={styles.textTranslation}>
+									{showTranslations[comment.id]
+										? t("viewOriginalButton")
+										: t("translateButton")}
+								</Text>
+							</TouchableOpacity>
+						)}
+
 						<ModalTranslationsCount
 							modalVisible={modalTranslationVisible}
 							setModalVisible={setModalTranslationVisible}
@@ -476,22 +490,30 @@ const ItemComment = ({ commentList = [], onReply }) => {
 										position={modalPosition}
 									/>
 								)}
-								<TouchableOpacity
-									style={styles.textTranslation}
-									onPress={() => {
-										handleTranslate(reply.id, false);
-										handleToggleTranslation(
-											reply.id,
-											false,
-										);
-									}}
-								>
-									<Text style={styles.textTranslation}>
-										{replyShowTranslations[reply.id]
-											? t("viewOriginalButton")
-											: t("translateButton")}
-									</Text>
-								</TouchableOpacity>
+
+								{translating[reply.id] ? (
+									<View style={styles.textTranslation}>
+										<LoadingDots />
+									</View>
+								) : (
+									<TouchableOpacity
+										style={styles.textTranslation}
+										onPress={() => {
+											handleTranslate(reply.id, false);
+											handleToggleTranslation(
+												reply.id,
+												false,
+											);
+										}}
+									>
+										<Text style={styles.textTranslation}>
+											{replyShowTranslations[reply.id]
+												? t("viewOriginalButton")
+												: t("translateButton")}
+										</Text>
+									</TouchableOpacity>
+								)}
+
 								<ModalTranslationsCount
 									modalVisible={modalTranslationVisible}
 									setModalVisible={setModalTranslationVisible}

--- a/src/components/connect/ConnectCard.js
+++ b/src/components/connect/ConnectCard.js
@@ -119,7 +119,10 @@ const ConnectCard = ({
 	};
 
 	return (
-		<View style={[styles.rectangle, fail && { justifyContent: "center" }]}>
+		<TouchableOpacity
+			style={[styles.rectangle, fail && { justifyContent: "center" }]}
+			onPress={handleNavigation}
+		>
 			{fail ? (
 				<View style={styles.containerFail}>
 					<IconSearchFail />
@@ -201,14 +204,12 @@ const ConnectCard = ({
 											: handleCreateHeart
 								}
 							/>
-							<TouchableOpacity onPress={handleNavigation}>
-								<ConnectPlusIcon style={{ marginLeft: 9 }} />
-							</TouchableOpacity>
+							<ConnectPlusIcon style={{ marginLeft: 9 }} />
 						</View>
 					</View>
 				</>
 			)}
-		</View>
+		</TouchableOpacity>
 	);
 };
 

--- a/src/components/home/HomeProfile.js
+++ b/src/components/home/HomeProfile.js
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 		height: 136,
 		justifyContent: "center",
 		alignItems: "center",
-		backgroundColor: "#B0D0FF60",
+		backgroundColor: "#B0D0FF",
 		borderRadius: 16,
 		overflow: "hidden",
 	},

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -313,8 +313,12 @@ export const getLikedPost = () => {
 	return api.get("/likes");
 };
 
-export const getBookmarkedPostChat = () => {
-	return api.get("/bookmarks");
+export const getBookmarkedByBoardType = (boardType) => {
+	return api.get("/bookmarks/", {
+		params: {
+			boardType,
+		},
+	});
 };
 
 export const getBookmarkedByChatroomId = (chatroomId) => {

--- a/src/pages/chat/BookmarkPage.jsx
+++ b/src/pages/chat/BookmarkPage.jsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
 
 import BookmarkStyles from "@pages/chat/BookmarkStyles";
-import { getBookmarkedPostChat } from "config/api";
+import { getBookmarkedByChatroomId } from "config/api";
 
 import TopBar from "@components/common/TopBar";
 import Bookmark from "@components/chat/Bookmark";
@@ -17,7 +17,8 @@ const BookmarkPage = () => {
 	useEffect(() => {
 		const handleBookmarkPost = async () => {
 			try {
-				const response = await getBookmarkedPostChat();
+				const response = await getBookmarkedByChatroomId("");
+				console.log(response.data);
 				const filterdBookmark = response.data.filter(
 					(item) => item.post === null,
 				);

--- a/src/pages/chat/BookmarkPage.jsx
+++ b/src/pages/chat/BookmarkPage.jsx
@@ -18,7 +18,6 @@ const BookmarkPage = () => {
 		const handleBookmarkPost = async () => {
 			try {
 				const response = await getBookmarkedByChatroomId("");
-				console.log(response.data);
 				const filterdBookmark = response.data.filter(
 					(item) => item.post === null,
 				);

--- a/src/pages/chat/ChatBubble/ChatBubble.jsx
+++ b/src/pages/chat/ChatBubble/ChatBubble.jsx
@@ -12,6 +12,7 @@ import ChatBubbleLeftTrailSVG from "./ChatBubbleLeftTrailSVG";
 import IconChatProfile from "@components/chat/IconChatProfile";
 import ModalMenuChat from "@components/chat/ModalMenuChat";
 import ModalTranslationsCount from "@components/common/ModalTranslationsCount";
+import LoadingDots from "@components/common/loading/LoadingDots";
 
 const { fontNavi } = CustomTheme;
 
@@ -36,6 +37,7 @@ const ChatBubble = ({
 	const [modalTranslationVisible, setModalTranslationVisible] =
 		useState(false);
 	const [chatMessage, setChatMessage] = useState(message);
+	const [translating, setTranslating] = useState(false);
 
 	const handleLongPress = () => {
 		Haptics.selectionAsync();
@@ -60,13 +62,17 @@ const ChatBubble = ({
 				if (translationCount === 0) {
 					setModalTranslationVisible(true);
 					setIsTranslation(true);
+					setTranslating(true);
 					const response = await translationByChatId(chatId);
 					setChatMessage(response.data.translations[0].text);
+					setTranslating(false);
 				} else if (translationCount <= 15) {
 					setModalTranslationVisible(false);
 					setIsTranslation(true);
+					setTranslating(true);
 					const response = await translationByChatId(chatId);
 					setChatMessage(response.data.translations[0].text);
+					setTranslating(false);
 				} else if (translationCount > 15) {
 					setModalTranslationVisible(true);
 				}
@@ -138,18 +144,38 @@ const ChatBubble = ({
 								</TouchableOpacity>
 							)}
 						</View>
-						<TouchableOpacity
-							activeOpacity={1}
-							style={bubbleStyles}
-							onLongPress={handleLongPress}
-						>
-							<Text
-								style={[messageStyles, styles.absoluteText]}
-								ref={bubbleRef}
+						{translating ? (
+							<View
+								style={[
+									bubbleStyles,
+									{
+										height: 35,
+									},
+								]}
 							>
-								{isTranslation ? chatMessage : message}
-							</Text>
-						</TouchableOpacity>
+								<View
+									style={[
+										bubbleStyles,
+										{ left: 2, bottom: -5 },
+									]}
+								>
+									<LoadingDots />
+								</View>
+							</View>
+						) : (
+							<TouchableOpacity
+								activeOpacity={1}
+								style={bubbleStyles}
+								onLongPress={handleLongPress}
+							>
+								<Text
+									style={[messageStyles, styles.absoluteText]}
+									ref={bubbleRef}
+								>
+									{isTranslation ? chatMessage : message}
+								</Text>
+							</TouchableOpacity>
+						)}
 						<View
 							style={[
 								styles.trailContainer,

--- a/src/pages/chat/ChattingPage.jsx
+++ b/src/pages/chat/ChattingPage.jsx
@@ -97,19 +97,9 @@ const ChattingPage = () => {
 		try {
 			const response = await getChatroomsByType("SINGLE");
 
-			const sortedChatrooms = response?.data.sort((a, b) => {
-				const latestMessageA =
-					messages[a.id]?.[messages[a.id].length - 1];
-				const latestMessageB =
-					messages[b.id]?.[messages[b.id].length - 1];
-
-				const timeA = latestMessageA
-					? new Date(latestMessageA.created)
-					: new Date(a.created);
-				const timeB = latestMessageB
-					? new Date(latestMessageB.created)
-					: new Date(b.created);
-
+			const sortedChatrooms = response.data.sort((a, b) => {
+				const timeA = new Date(a.lastChat.created);
+				const timeB = new Date(b.lastChat.created);
 				return timeB - timeA;
 			});
 			setSingleChatRoomList(sortedChatrooms);
@@ -162,8 +152,13 @@ const ChattingPage = () => {
 							chatroomInfo={item}
 							myMemberId={myMemberId}
 							name={item.name || "Unknown"}
-							context={getLatestMessage(item.id, item.lastChat)}
-							time={formatKoreanTime(item.created)}
+							content={getLatestMessage(
+								item.id,
+								item.lastChat.message,
+							)}
+							lastChatCreated={formatKoreanTime(
+								item.lastChat.created,
+							)}
 							onCompleteExit={onCompleteExit}
 							unreadChatsCount={item.unreadChatsCount}
 						/>

--- a/src/pages/community/PostPage.jsx
+++ b/src/pages/community/PostPage.jsx
@@ -49,6 +49,7 @@ import ModalKebabMenu from "@components/community/ModalKebabMenu";
 import ModalTranslationsCount from "@components/common/ModalTranslationsCount";
 import IconProfileBackground from "@components/community/IconProfileBackground";
 import IconProfileUser24 from "@components/common/IconProfileUser24";
+import LoadingDots from "@components/common/loading/LoadingDots";
 
 const PostPage = ({ route }) => {
 	const { t } = useTranslation();
@@ -82,6 +83,7 @@ const PostPage = ({ route }) => {
 	const [translationCount, setTranslationCount] = useState();
 	const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
 	const [profilePresignUrl, setProfilePresignUrl] = useState(null);
+	const [translating, setTranslating] = useState(false);
 
 	const commentRef = useRef(null);
 	const scrollViewRef = useRef(null);
@@ -388,15 +390,19 @@ const PostPage = ({ route }) => {
 				if (translationCount === 0) {
 					setModalTranslationVisible(true);
 					setIsTranslation(true);
+					setTranslating(true);
 					const response = await translationByPostId(postId);
 					setTitle(response.data.translations[0].text);
 					setContext(response.data.translations[1].text);
+					setTranslating(false);
 				} else if (translationCount <= 15) {
 					setModalTranslationVisible(false);
 					setIsTranslation(true);
+					setTranslating(true);
 					const response = await translationByPostId(postId);
 					setTitle(response.data.translations[0].text);
 					setContext(response.data.translations[1].text);
+					setTranslating(false);
 				} else if (translationCount > 15) {
 					setModalTranslationVisible(true);
 				}
@@ -538,16 +544,24 @@ const PostPage = ({ route }) => {
 							<IconBookmark active={pressBookmark} size="24" />
 							<Text style={PostStyles.textIcon}>{bookmark}</Text>
 						</TouchableOpacity>
-						<TouchableOpacity
-							style={PostStyles.textTranslation}
-							onPress={handleTranslations}
-						>
-							<Text style={PostStyles.textTranslation}>
-								{isTranslation
-									? t("viewOriginalButton")
-									: t("translateButton")}
-							</Text>
-						</TouchableOpacity>
+
+						{translating ? (
+							<View style={PostStyles.textTranslation}>
+								<LoadingDots />
+							</View>
+						) : (
+							<TouchableOpacity
+								style={PostStyles.textTranslation}
+								onPress={handleTranslations}
+							>
+								<Text style={PostStyles.textTranslation}>
+									{isTranslation
+										? t("viewOriginalButton")
+										: t("translateButton")}
+								</Text>
+							</TouchableOpacity>
+						)}
+
 						<ModalTranslationsCount
 							modalVisible={modalTranslationVisible}
 							setModalVisible={setModalTranslationVisible}

--- a/src/pages/member/BookmarkedPostPage.jsx
+++ b/src/pages/member/BookmarkedPostPage.jsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import * as Sentry from "@sentry/react-native";
 
 import BookmarkedPostStyles from "@pages/member/BookmarkedPostStyles";
-import { getBookmarkedPostChat } from "config/api";
+import { getBookmarkedByBoardType } from "config/api";
 import { communityPresignUrl } from "util/communityPresignUrl";
 
 import TopBar from "@components/common/TopBar";
@@ -21,7 +21,14 @@ const BookmarkedPostPage = ({ route }) => {
 	useEffect(() => {
 		const handleBookmarkPost = async () => {
 			try {
-				const bookmarkPostResponse = await getBookmarkedPostChat();
+				let category = "";
+				if (selectedCategory === t("tipBoard")) {
+					category = "TIP";
+				} else if (selectedCategory === t("freeBoard")) {
+					category = "FREE";
+				}
+				const bookmarkPostResponse =
+					await getBookmarkedByBoardType(category);
 				const filterdBookmark = bookmarkPostResponse.data.filter(
 					(item) => item.post !== null,
 				);
@@ -36,7 +43,7 @@ const BookmarkedPostPage = ({ route }) => {
 			}
 		};
 		handleBookmarkPost();
-	}, []);
+	}, [selectedCategory]);
 
 	const handleCategoryPress = (category) => {
 		setSelectedCategory(category);

--- a/src/pages/member/TabBookmarkPostPage.jsx
+++ b/src/pages/member/TabBookmarkPostPage.jsx
@@ -6,7 +6,7 @@ import * as Sentry from "@sentry/react-native";
 
 import TabBookmarkPostStyles from "@pages/member/TabBookmarkPostStyles";
 import { CustomTheme } from "@styles/CustomTheme";
-import { getBookmarkedPostChat } from "config/api";
+import { getBookmarkedByBoardType } from "config/api";
 import { communityPresignUrl } from "util/communityPresignUrl";
 
 import ItemLikeBookmark from "@components/member/ItemLikeBookmark";
@@ -22,7 +22,8 @@ const TabBookmarkPostPage = () => {
 		useCallback(() => {
 			const handleBookmarkPost = async () => {
 				try {
-					const bookmarkPostResponse = await getBookmarkedPostChat();
+					const bookmarkPostResponse =
+						await getBookmarkedByBoardType("");
 					const filterdBookmark = bookmarkPostResponse.data.filter(
 						(item) => item.post !== null,
 					);


### PR DESCRIPTION
### 개요
베타테스트 및 12/28, 1/2 회의 내용 피드백 수정사항
<br>

### 수정사항
- 커넥트 카드의 터치 영역을 플러스 버튼에서 카드 전체로 확장
- 채팅 목록 정렬을 마지막 채팅 시간 기준으로 수정
- 게시판 북마크 필터 api 연결 및 수정
- 게시판, 채팅, 북마크 페이지에서 번역하기 클릭 시 로딩 아이콘 표시
- 홈 카드 프로필의 잘못 적용된 백그라운드컬러 수정

자세한 내용은 커밋 참고 부탁드립니다!

<br>

### 수정사항
**커넥트 카드의 터치 영역을 플러스 버튼에서 카드 전체로 확장**

https://github.com/user-attachments/assets/48c04b62-4e7d-44e1-bcb7-cb9984e2f481

<br><br>

**채팅 목록 정렬을 마지막 채팅 시간 기준으로 수정**
와이파이 환경이 불안정하여 현재 시뮬레이터로 테스트 중이라 채팅 관련 테스트를 진행하지 못하는 상황입니다. 추후 테스트 화면을 추가하겠습니다!

<br><br>

**게시판 북마크 필터 api 연결 및 수정**

https://github.com/user-attachments/assets/3a73d0d6-81a0-462d-9ee7-fe393dee93ee

<br><br>

**게시판, 채팅, 북마크 페이지에서 번역하기 클릭 시 로딩 아이콘 표시**

https://github.com/user-attachments/assets/c000def7-1618-466a-a7e8-a2d55b52ed18

https://github.com/user-attachments/assets/4ed19d41-26ca-4fd3-9555-cb55794920b1

<br><br>

**홈 카드 프로필의 잘못 적용된 백그라운드컬러 수정**

<img src="https://github.com/user-attachments/assets/dfc604f4-e0c8-4ade-9358-8842ccab9c92" width="40%" height="40%">

<br><br>
