### PR TITLE
fix: 온보딩 세션 학생증 인증 기능 복원 및 인증 대기 화면 문구 수정

### DIFF
--- a/src/pages/onboarding/CompleteProfilePage.js
+++ b/src/pages/onboarding/CompleteProfilePage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { View, Text, SafeAreaView, Dimensions } from "react-native";
-// import { useNavigation } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 
 import CompleteProfileStyles from "@pages/onboarding/CompleteProfileStyles";
@@ -8,30 +8,25 @@ import CompleteProfileStyles from "@pages/onboarding/CompleteProfileStyles";
 import IconLoading from "@components/onboarding/IconLoading";
 import ApplyButton from "@components/common/ApplyButton";
 
-import { useAuth } from "src/states/AuthContext";
-
 const CompleteProfilePage = () => {
 	const { t } = useTranslation();
 
-	// const navigation = useNavigation();
+	const navigation = useNavigation();
 
 	const { height: screenHeight } = Dimensions.get("window");
 	const isSmallScreen = screenHeight < 700;
-
-	const { setIsLoggedIn } = useAuth();
-
-	const handleMove = () => {
-		setIsLoggedIn(true);
-	};
 
 	return (
 		<SafeAreaView style={[CompleteProfileStyles.container]}>
 			<Text style={CompleteProfileStyles.textTitle}>
 				{t("profileCompletionTitle")}
 			</Text>
-			{/* <Text style={CompleteProfileStyles.textSubTitle}>
+			<Text style={CompleteProfileStyles.textSubTitle}>
 				{t("profileCompletionDescription")}
-			</Text> */}
+			</Text>
+			<Text style={CompleteProfileStyles.textDescription}>
+				{t("averageVerificationTime")}
+			</Text>
 			<View style={CompleteProfileStyles.iconLoading}>
 				<IconLoading />
 			</View>
@@ -42,10 +37,8 @@ const CompleteProfilePage = () => {
 				]}
 			>
 				<ApplyButton
-					// text={t("confirmButtonText")}
-					text="홈 화면으로 이동"
-					// onPress={() => navigation.navigate("LoadingVerification")}
-					onPress={handleMove}
+					text={t("confirmButtonText")}
+					onPress={() => navigation.navigate("LoadingVerification")}
 				/>
 			</View>
 		</SafeAreaView>

--- a/src/pages/onboarding/CompleteProfileStyles.js
+++ b/src/pages/onboarding/CompleteProfileStyles.js
@@ -1,7 +1,7 @@
 import { StyleSheet } from "react-native";
 import { CustomTheme } from "@styles/CustomTheme.js";
 
-const { fontHead24, fontHead18 } = CustomTheme;
+const { fontHead24, fontHead18, fontSub16 } = CustomTheme;
 
 const CompleteProfileStyles = StyleSheet.create({
 	container: {
@@ -15,8 +15,14 @@ const CompleteProfileStyles = StyleSheet.create({
 	},
 	textSubTitle: {
 		...fontHead18,
-		color: CustomTheme.primaryMedium,
+		color: CustomTheme.textPrimary,
 		marginTop: 12,
+		marginHorizontal: 24,
+	},
+	textDescription: {
+		...fontSub16,
+		color: CustomTheme.primaryMedium,
+		marginTop: 4,
 		marginHorizontal: 24,
 	},
 	iconLoading: {

--- a/src/pages/onboarding/ProfileLanguagePage.js
+++ b/src/pages/onboarding/ProfileLanguagePage.js
@@ -97,7 +97,7 @@ const ProfileLanguagePage = () => {
 			);
 		}
 
-		// navigation.navigate("StudentVerification");
+		navigation.navigate("StudentVerification");
 	};
 
 	const { height: screenHeight } = Dimensions.get("window");

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -123,6 +123,7 @@
 
 	"profileCompletionTitle": "Profile Creation Complete!",
 	"profileCompletionDescription": "Please wait a moment for student verification confirmation",
+	"averageVerificationTime": "It usually takes about 1 day to complete the verification.",
 
 	"connect": "Connect",
 	"newFriendText": "Join with new friends!",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -123,6 +123,7 @@
 
 	"profileCompletionTitle": "¡Creación de Perfil Completa!",
 	"profileCompletionDescription": "Por favor, espera un momento para la confirmación de la verificación de estudiante",
+	"averageVerificationTime": "La verificación suele tardar aproximadamente 1 día en completarse.",
 
 	"connect": "Conectar",
 	"newFriendText": "¡Con nuevos amigos!",

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -123,6 +123,7 @@
 
 	"profileCompletionTitle": "プロフィール作成完了！",
 	"profileCompletionDescription": "学生認証確認までしばらくお待ちください",
+	"averageVerificationTime": "認証完了まで平均1日ほどかかります。",
 
 	"connect": "コネクト",
 	"newFriendText": "新しい友達と参加しよう！",

--- a/src/translations/ko.json
+++ b/src/translations/ko.json
@@ -123,6 +123,7 @@
 
 	"profileCompletionTitle": "프로필 생성 완료!",
 	"profileCompletionDescription": "재학생 인증 확인까지 잠시만 기다려주세요",
+	"averageVerificationTime": "인증 완료까지 평균 1일 정도 걸려요.",
 
 	"connect": "커넥트",
 	"newFriendText": "새로운 친구와 함께해요!",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -123,6 +123,7 @@
 
 	"profileCompletionTitle": "个人资料创建完成！",
 	"profileCompletionDescription": "请稍等片刻以确认学生认证",
+	"averageVerificationTime": "认证完成大约需要1天时间。",
 
 	"connect": "连接",
 	"newFriendText": "和新朋友一起加入吧！",


### PR DESCRIPTION
### 개요
베타테스트를 위해 지워놨던 학생증 인증 화면 복구, 인증 대기 화면 문구 수정
<br>

### 수정사항
- 온보딩 세션 학생증 인증 기능 복원 및 인증 대기 화면 문구 수정

<br>

### 테스트 화면
**온보딩 세션 학생증 인증 기능 복원 및 인증 대기 화면 문구 수정**
시뮬레이터를 사용 중이라, 테스트 화면 녹화 중에만 이미지를 생략하고 진행할 수 있도록 설정하였습니다!

https://github.com/user-attachments/assets/8d1a37b7-372e-4598-904e-606a5bb68f30

<br><br>