### PR TITLE
hotfix/login-expo-token-1: DEV브랜치에만 미반영되었던 apnsToken 삭제

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -544,9 +544,9 @@ export const getMyComments = () => {
 	return api.get("/members/comments");
 };
 
-export const createNotificationToken = (apnsToken, deviceId) => {
+export const createNotificationToken = (pushToken, deviceId) => {
 	return api.post("/notifications/push", {
-		apnsToken,
+		pushToken,
 		deviceId,
 	});
 };


### PR DESCRIPTION
@nnyouung @seungholee-dev 

#209 중복사항으로 해당 PR 우선 merge했습니다!
- 현재 DEV에서 로그인시에 알림토큰으로 인한 에러문구가떠서 apnsToken 삭제 우선 merge하겠습니다!
