### PR TITLE
refactor/notification-view-and-onboarding-hooby:알림 페이지 랜딩 변경 & 존재하지 않는 사용자 시 모달 표시 & 온보딩에서 취미 저장 형식 변경

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -38,9 +38,7 @@ export default {
 			bundleIdentifier: getIOSBundleIdentifier(),
 			infoPlist: {
 				CFBundleDisplayName: getAppName(),
-			},
-			config: {
-				usesNonExemptEncryption: false,
+				UIBackgroundModes: ["fetch", "remote-notification"],
 			},
 		},
 		android: {

--- a/src/components/member/ModalKebabNotFoundMember.jsx
+++ b/src/components/member/ModalKebabNotFoundMember.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import Modal from "react-native-modal";
+import { useTranslation } from "react-i18next";
+
+import { CustomTheme } from "@styles/CustomTheme";
+
+const ModalKebabNotFoundMember = ({ modalVisible, setModalVisible }) => {
+	const { t } = useTranslation();
+
+	return (
+		<Modal
+			isVisible={modalVisible}
+			style={styles.modal}
+			onBackdropPress={() => setModalVisible(false)}
+			backdropColor="rgba(0, 0, 0, 0.5)"
+			animationIn="fadeIn"
+			animationOut="fadeOut"
+		>
+			<View style={styles.rectangle}>
+				<Text style={styles.description}>{t("notFoundMember")}</Text>
+				<View style={styles.line} />
+				<TouchableOpacity onPress={() => setModalVisible(false)}>
+					<Text style={styles.text}>{t("close")}</Text>
+				</TouchableOpacity>
+			</View>
+		</Modal>
+	);
+};
+
+const styles = StyleSheet.create({
+	modal: {
+		justifyContent: "center",
+		alignItems: "center",
+		flex: 1,
+	},
+	rectangle: {
+		width: 250,
+		padding: 20,
+		backgroundColor: "rgba(0, 0, 0, 0.6)",
+		borderRadius: 10,
+		alignItems: "center",
+	},
+	line: {
+		width: "100%",
+		height: 1,
+		backgroundColor: "rgba(255, 255, 255, 0.3)",
+		marginHorizontal: 5,
+	},
+	description: {
+		fontSize: 18,
+		color: "#ccc",
+		marginVertical: 9,
+	},
+
+	text: {
+		fontSize: 18,
+		color: CustomTheme.primaryMedium,
+		marginVertical: 9,
+	},
+});
+
+export default ModalKebabNotFoundMember;

--- a/src/components/notification/NotificationCard.js
+++ b/src/components/notification/NotificationCard.js
@@ -6,7 +6,9 @@ import { CustomTheme } from "@styles/CustomTheme";
 
 import IconAddFriend24 from "@components/Icon24/IconAddFriend24";
 import IconHeart24 from "@components/Icon24/IconHeart24";
+import { getProfileById } from "config/api";
 import { useNavigation } from "@react-navigation/native";
+import ModalKebabNotFoundMember from "@components/member/ModalKebabNotFoundMember";
 
 const { fontCaption, fontNavi } = CustomTheme;
 
@@ -19,9 +21,12 @@ const NotificationCard = ({
 }) => {
 	const navigation = useNavigation();
 	const [isRead, setIsRead] = useState(false);
+	const [modalVisible, setModalVisible] = useState(false);
 
 	let iconSvg;
 	if (type === "CONNECT") {
+		iconSvg = <IconAddFriend24 />;
+	} else if (type === "CONNECT_ACCEPT") {
 		iconSvg = <IconAddFriend24 />;
 	} else if (type === "POST") {
 		iconSvg = <IconHeart24 />;
@@ -49,7 +54,22 @@ const NotificationCard = ({
 			"true",
 		);
 		if (type === "CONNECT") {
+			console.log(typeId);
+			const response = await getProfileById(typeId);
+			console.log(response.data);
+			if (response.data.isDeleted) {
+				setModalVisible(true);
+				return;
+			}
 			navigation.navigate("ConnectProfilePage", { memberId: typeId });
+		} else if (type === "CONNECT_ACCEPT") {
+			const response = await getProfileById(typeId);
+			console.log(response.data);
+			if (response.data.isDeleted) {
+				setModalVisible(true);
+				return;
+			}
+			navigation.navigate("ConnectListPage", { screen: "그룹" });
 		} else if (type === "POST") {
 			navigation.navigate("PostPage", { postId: typeId });
 		} else {
@@ -58,20 +78,27 @@ const NotificationCard = ({
 	};
 
 	return (
-		<TouchableOpacity
-			style={[styles.rectangle, isRead && { opacity: 0.4 }]}
-			onPress={handleNotification}
-		>
-			<View style={styles.notify}>
-				<View style={styles.iconTextContainer}>
-					<View style={styles.icon}>{iconSvg}</View>
-					<View style={styles.textContainer}>
-						<Text style={styles.context}>{content}</Text>
+		<>
+			<ModalKebabNotFoundMember
+				modalVisible={modalVisible}
+				setModalVisible={setModalVisible}
+			/>
+
+			<TouchableOpacity
+				style={[styles.rectangle, isRead && { opacity: 0.4 }]}
+				onPress={handleNotification}
+			>
+				<View style={styles.notify}>
+					<View style={styles.iconTextContainer}>
+						<View style={styles.icon}>{iconSvg}</View>
+						<View style={styles.textContainer}>
+							<Text style={styles.context}>{content}</Text>
+						</View>
 					</View>
+					<Text style={styles.time}>{created}</Text>
 				</View>
-				<Text style={styles.time}>{created}</Text>
-			</View>
-		</TouchableOpacity>
+			</TouchableOpacity>
+		</>
 	);
 };
 
@@ -112,6 +139,35 @@ const styles = StyleSheet.create({
 		...fontNavi,
 		color: CustomTheme.textDisable,
 		marginRight: 28,
+	},
+	container: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		backgroundColor: "white",
+	},
+	modalContainer: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		backgroundColor: "rgba(0, 0, 0, 0.5)",
+	},
+	modalContent: {
+		width: 250,
+		padding: 20,
+		backgroundColor: "rgba(255, 255, 255, 0.7)",
+		borderRadius: 10,
+		alignItems: "center",
+	},
+	modalText: {
+		fontSize: 17,
+		marginBottom: 10,
+	},
+	modalDivider: {
+		width: "100%",
+		height: 1,
+		backgroundColor: "#ccc",
+		marginVertical: 5,
 	},
 });
 

--- a/src/pages/onboarding/OnboardingStep6Page.js
+++ b/src/pages/onboarding/OnboardingStep6Page.js
@@ -65,7 +65,7 @@ const OnboardingStep6Page = ({ stepData, saveData }) => {
 		if (stepData[3].selectedMBTI !== t("mbtiNoneOption")) {
 			formData.append("mbti", stepData[3].selectedMBTI);
 		}
-		formData.append("hobbies", JSON.stringify(stepData[4].selectedHobby));
+		formData.append("hobbies", stepData[4].selectedHobby);
 		formData.append("languages", stepData[5].selectedLanguages);
 		const memberId = await SecureStore.getItemAsync("memberId");
 
@@ -88,6 +88,7 @@ const OnboardingStep6Page = ({ stepData, saveData }) => {
 
 		try {
 			await updateMyProfile(formData);
+			console.log(formData);
 			navigation.replace("CompleteProfilePage");
 		} catch (error) {
 			Sentry.captureException(error);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -414,5 +414,7 @@
 	"connectRequestSuccess": "You have sent a connect request to {{username}}.",
 
 	"exitChatroomButton": "Leave",
-	"exitChatroom": "Leave Chat"
+	"exitChatroom": "Leave Chat",
+	"close": "Close",
+	"notFoundMember": "User not found"
 }

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -415,5 +415,7 @@
 	"connectRequestSuccess": "Has enviado una solicitud de conexión a {{username}}.",
 
 	"exitChatroomButton": "Salir",
-	"exitChatroom": "Salir del chat"
+	"exitChatroom": "Salir del chat",
+	"close": "Cerrar",
+	"notFoundMember": "Usuario no encontrado"
 }

--- a/src/translations/ja.json
+++ b/src/translations/ja.json
@@ -415,5 +415,7 @@
 	"connectRequestSuccess": "{{username}}にコネクトリクエストを送りました。",
 
 	"exitChatroomButton": "退出",
-	"exitChatroom": "チャットを離れる"
+	"exitChatroom": "チャットを離れる",
+	"close": "閉じる",
+	"notFoundMember": "ユーザーが見つかりません"
 }

--- a/src/translations/ko.json
+++ b/src/translations/ko.json
@@ -414,5 +414,7 @@
 	"connectRequestSuccess": "{{username}}에게\n커넥트 요청하였습니다.",
 
 	"exitChatroomButton": "나가기",
-	"exitChatroom": "채팅 나가기"
+	"exitChatroom": "채팅 나가기",
+	"close": "닫기",
+	"notFoundMember": "찾을 수 없는 사용자입니다"
 }

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -415,5 +415,7 @@
 	"connectRequestSuccess": "您已向{{username}}发送连接请求。",
 
 	"exitChatroomButton": "离开",
-	"exitChatroom": "离开聊天"
+	"exitChatroom": "离开聊天",
+	"close": "关闭",
+	"notFoundMember": "未找到用户"
 }


### PR DESCRIPTION
### 개요
- 알림 카드 랜딩 연결 (아래 설명에서 참고 부탁드립니다!)
- 온보딩에서 "["SNS", "READ" ... ]" 형식으로 저장되었던 것 List<String>으로 저장되도록 수정

---

커넥팅 요청 시 -> 알림 카드 선택 시에 Connect List 페이지로 랜더링
- 바로 커넥팅 여부를 결정할 때 쉬워질 것이라고 판단했기 때문입니다

https://github.com/user-attachments/assets/1a68c55f-c702-47fa-bb77-052f0d327a54

---

알림 카드 선택 했는데 
존재하는 사용자일 경우 (커넥트 생성 완료되었다면) -> 회원 상세 페이지

 

https://github.com/user-attachments/assets/41db4c32-49c7-4c27-9803-bde37d1087fa




존재하지 않는 사용자일 경우 -> 모달로 존재하지 않는 사용자임을 보여줍니다

https://github.com/user-attachments/assets/4a77b5d7-9964-40ed-9cad-3584cd411299


