### PR TITLE
fix(cd): github action checkout 에러 해결 

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -5,8 +5,6 @@ on:
 jobs:
     preview:
         runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
         steps:
             - name: 🏗 Setup repo
               uses: actions/checkout@v3


### PR DESCRIPTION
기존에 명시 되어있는 permission 때문에 private 리포에서 기본 action
permission이 override되는 상황
따라서 명시된 permission 삭제