### PR TITLE
hotfix/notification-chatroom: 응답 형식의 오류 해결

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -293,7 +293,7 @@ function AppContent() {
 			} else if (type === "REQUEST") {
 				navigation.navigate("ConnectListPage", { screen: "그룹" });
 			} else if (type === "CHATROOM" && chatroomInfo) {
-				navigation.navigate("ChatRoomPage", {chatroomInfo});
+				navigation.navigate("ChatRoomPage", { chatroomInfo });
 			} else {
 				null;
 			}

--- a/App.jsx
+++ b/App.jsx
@@ -293,7 +293,7 @@ function AppContent() {
 			} else if (type === "REQUEST") {
 				navigation.navigate("ConnectListPage", { screen: "그룹" });
 			} else if (type === "CHATROOM" && chatroomInfo) {
-				navigation.navigate("ChatRoomPage", chatroomInfo);
+				navigation.navigate("ChatRoomPage", {chatroomInfo});
 			} else {
 				null;
 			}


### PR DESCRIPTION
chatroomId 만 받아 채팅방 알림 배너 클릭시 Crash 났던 사항을 백엔드의 채팅방 응답 DTO인 chatroomInfo 형식으로 받는 것으로 수정해 오류를 수정했습니다