### PR TITLE
hotfix/chatroomPage-time-split-issue-1: 채팅방에서 접속한 사용자의 위치에 따라 날짜 감지 못하는 이슈 해결

### DIFF
--- a/src/pages/chat/ChatRoomPage.jsx
+++ b/src/pages/chat/ChatRoomPage.jsx
@@ -226,11 +226,14 @@ const ChatRoomPage = ({ route }) => {
 		};
 		const locale = localeMap[userLanguage] || "en-US";
 
+		const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 		const formatter = new Intl.DateTimeFormat(locale, {
 			year: "numeric",
 			month: "2-digit",
 			day: "2-digit",
 			weekday: "long",
+			userTimeZone,
 		});
 
 		return formatter.format(messageDate);


### PR DESCRIPTION
#### 문제 원인
Intl.DateTimeFormat을 사용하여 날짜를 포맷할 때, 날짜가 UTC(협정 세계시) 기준으로 처리되고 사용자의 로컬 타임존을 반영하지 않으면, 기본적으로 브라우저 또는 환경의 타임존에 맞춰서 포맷되기 때문이라고 합니다.

같은 날짜에 보낸 채팅인데도 다른 날짜로 감지하고 있던 사항
<img src="https://github.com/user-attachments/assets/892a898c-d8a9-4cc3-be72-ebe1a50e77b1" width="300" >




#### 문제 해결
Intl.DateTimeFormat().resolvedOptions().timeZone 로 타임존 감지 후 변경


