### PR TITLE
hotfix/accesspage-firstlaunch-securestore-1: 앱 삭제 후 설치 시에 온보딩 페이지가 보이도록

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -224,7 +224,6 @@ function App() {
 function AppContent() {
 	const navigation = useNavigation();
 	const { isLoggedIn, setIsLoggedIn } = useAuth();
-	const [initialRoute, setInitialRoute] = useState("Access");
 
 	useEffect(() => {
 		const checkAutoLogin = async () => {
@@ -264,13 +263,7 @@ function AppContent() {
 	useEffect(() => {
 		const checkAccess = async () => {
 			const { status } = await Notifications.getPermissionsAsync();
-			if (status === "granted") {
-				console.log("알림 권한 부여");
-				setInitialRoute("Login");
-			} else {
-				console.log("알림 권한 거부");
-				setInitialRoute("Login");
-			}
+			console.log("알림 권한 상태:", status);
 		};
 
 		checkAccess();
@@ -340,7 +333,7 @@ function AppContent() {
 			</PostModifyProvider>
 		</WebSocketProvider>
 	) : (
-		<AuthNavigator initialRoute={initialRoute} />
+		<AuthNavigator />
 	);
 }
 

--- a/src/pages/login/AccessPage.js
+++ b/src/pages/login/AccessPage.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { View, Text, SafeAreaView } from "react-native";
 import * as Notifications from "expo-notifications";
 import { useNavigation } from "@react-navigation/native";
@@ -28,16 +28,27 @@ const AccessPage = () => {
 				console.warn("알림 권한이 거부되었습니다.");
 			}
 		}
+		await new Promise((resolve) => setTimeout(resolve, 300));
 
-		const firstLaunch = await SecureStore.getItem("hasLaunched");
+		const firstLaunch = await SecureStore.getItemAsync("hasLaunched");
 
 		if (firstLaunch === null) {
-			navigation.navigate("LandingPage");
 			await SecureStore.setItemAsync("hasLaunched", "true");
+			navigation.reset({
+				index: 0,
+				routes: [{ name: "LandingPage" }],
+			});
 		} else {
-			navigation.replace("Login");
+			navigation.reset({
+				index: 0,
+				routes: [{ name: "Login" }],
+			});
 		}
 	};
+
+	useEffect(() => {
+		requestPermissions();
+	}, []);
 
 	return (
 		<SafeAreaView style={[AccessStyles.container]}>


### PR DESCRIPTION
- 앱이 처음 실행될 때 자동으로 실행되게 하려면 useEffect에 넣기
- SecureStore 값이 null인지 정확히 확인한 다음에 navigation 흐름을 제어해야 하기 때문에, navigation.reset() 을 사용