### PR TITLE
Fix/android UI 3: 안드로이드 관련 ui 수정

### DIFF
--- a/src/components/common/BottomTwoButtons.jsx
+++ b/src/components/common/BottomTwoButtons.jsx
@@ -44,23 +44,28 @@ const styles = StyleSheet.create({
 		alignItems: "center",
 		justifyContent: "center",
 		backgroundColor: CustomTheme.bgBasic,
+		paddingVertical: 14,
+		paddingBottom: Platform.OS == "android" ? 0 : 9,
 	},
 	rectangleShadow: {
 		flexDirection: "row",
 		width: "100%",
-		height: 110,
 		alignItems: "center",
 		justifyContent: "center",
 		backgroundColor: CustomTheme.bgBasic,
+		paddingVertical: 14,
 		...Platform.select({
 			ios: {
 				shadowColor: "#3C454E",
 				shadowOffset: { width: 0, height: -1 },
 				shadowOpacity: 0.1,
 				shadowRadius: 8,
+				paddingBottom: 9,
 			},
 			android: {
-				elevation: 3,
+				borderTopWidth: 1,
+				borderBottomWidth: 1,
+				borderColor: "rgba(205, 207, 213, 0.3)",
 			},
 		}),
 	},
@@ -75,8 +80,6 @@ const styles = StyleSheet.create({
 		borderRadius: 27,
 		marginLeft: 24,
 		marginRight: 8,
-		marginVertical: 9,
-		marginBottom: 14,
 	},
 	button2: {
 		width: 156,
@@ -89,8 +92,6 @@ const styles = StyleSheet.create({
 		borderRadius: 27,
 		marginRight: 24,
 		marginLeft: 8,
-		marginVertical: 9,
-		marginBottom: 14,
 	},
 	text1: {
 		...fontSub16,

--- a/src/components/connect/FilterBottomSlide.js
+++ b/src/components/connect/FilterBottomSlide.js
@@ -10,6 +10,7 @@ import {
 	PanResponder,
 	TouchableOpacity,
 	ScrollView,
+	Platform,
 } from "react-native";
 import { useTranslation } from "react-i18next";
 
@@ -415,7 +416,7 @@ const styles = StyleSheet.create({
 		backgroundColor: "white",
 		borderTopLeftRadius: 24,
 		borderTopRightRadius: 24,
-		paddingBottom: 75,
+		paddingBottom: Platform.OS === "android" ? 1 : 75,
 	},
 	line: {
 		width: 47,

--- a/src/components/connect/FilterBottomTwoButtons.jsx
+++ b/src/components/connect/FilterBottomTwoButtons.jsx
@@ -84,7 +84,9 @@ const styles = StyleSheet.create({
 				shadowRadius: 8,
 			},
 			android: {
-				elevation: 3,
+				borderTopWidth: 1,
+				borderBottomWidth: 1,
+				borderColor: "rgba(205, 207, 213, 0.3)",
 			},
 		}),
 	},

--- a/src/pages/connect/ConnectGuidePage.js
+++ b/src/pages/connect/ConnectGuidePage.js
@@ -7,6 +7,7 @@ import {
 	TouchableOpacity,
 	FlatList,
 	Dimensions,
+	Platform,
 } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -41,7 +42,7 @@ const TabBarUI = () => {
 				backgroundColor: "#fff",
 				borderTopWidth: 1,
 				borderTopColor: CustomTheme.bgList,
-				height: 84 - bottom,
+				height: Platform.OS === "android" ? 64 : 84 - bottom,
 			}}
 		>
 			<ChatDf24 />
@@ -204,7 +205,10 @@ const ConnectGuidePage = ({ closeModal }) => {
 			<View
 				style={{
 					position: "absolute",
-					top: likeUserPosition.y + top,
+					top:
+						Platform.OS == "android"
+							? likeUserPosition.y + 7
+							: likeUserPosition.y + top,
 					left: likeUserPosition.x - 151,
 					zIndex: 10,
 				}}
@@ -213,7 +217,7 @@ const ConnectGuidePage = ({ closeModal }) => {
 				<Text
 					style={[
 						ChatRoomStyles.iconGuideChatBubble,
-						{ top: 11, left: 10 },
+						{ top: 11, left: Platform.OS == "android" ? 5 : 10 },
 					]}
 				>
 					{t("savedProfileStorage")}
@@ -223,7 +227,11 @@ const ConnectGuidePage = ({ closeModal }) => {
 			<View
 				style={{
 					position: "absolute",
-					top: likePosition?.height && likePosition.height - 5,
+					top:
+						likePosition?.height &&
+						(Platform.OS == "android"
+							? likePosition.height - 60
+							: likePosition.height - 5),
 					left: likePosition?.width && likePosition.width - 155,
 					zIndex: 10,
 				}}
@@ -232,7 +240,7 @@ const ConnectGuidePage = ({ closeModal }) => {
 				<Text
 					style={[
 						ChatRoomStyles.iconGuideChatBubble,
-						{ top: 11, left: 9 },
+						{ top: 11, left: Platform.OS == "android" ? 4 : 9 },
 					]}
 				>
 					{t("saveProfileInstruction")}
@@ -242,7 +250,11 @@ const ConnectGuidePage = ({ closeModal }) => {
 				active={true}
 				style={{
 					position: "absolute",
-					top: likePosition?.height && likePosition.height + 65,
+					top:
+						likePosition?.height &&
+						(Platform.OS == "android"
+							? likePosition.height + 12
+							: likePosition.height + 65),
 					left: likePosition?.width && likePosition.width - 38,
 					zIndex: 10,
 				}}
@@ -251,7 +263,11 @@ const ConnectGuidePage = ({ closeModal }) => {
 			<View
 				style={{
 					position: "absolute",
-					top: likePosition?.height && likePosition.height * 2 - 5,
+					top:
+						likePosition?.height &&
+						(Platform.OS == "android"
+							? likePosition.height + 140
+							: likePosition.height * 2 - 5),
 					left: likePosition?.width && likePosition.width - 155,
 					zIndex: 10,
 				}}
@@ -260,7 +276,7 @@ const ConnectGuidePage = ({ closeModal }) => {
 				<Text
 					style={[
 						ChatRoomStyles.iconGuideChatBubble,
-						{ top: 11, left: 9 },
+						{ top: 11, left: Platform.OS == "android" ? 4 : 9 },
 					]}
 				>
 					{t("viewDetailsInstruction")}
@@ -269,7 +285,9 @@ const ConnectGuidePage = ({ closeModal }) => {
 					active={true}
 					style={{
 						position: "absolute",
-						top: likePosition?.height && 73,
+						top:
+							likePosition?.height &&
+							(Platform.OS == "android" ? 72 : 73),
 						left: likePosition?.width && 150,
 						zIndex: 10,
 					}}

--- a/src/pages/home/HomePage.js
+++ b/src/pages/home/HomePage.js
@@ -152,6 +152,7 @@ const HomePage = () => {
 		navigation.navigate("NotificationPage");
 	};
 
+	const { width: screenWidth } = Dimensions.get("window");
 	const { height: screenHeight } = Dimensions.get("window");
 	const isSmallScreen = screenHeight < 700;
 
@@ -267,7 +268,17 @@ const HomePage = () => {
 							</View>
 						) : currentProfileIndex < homeProfiles.length - 1 ? (
 							<>
-								<View style={HomeStyles.backgroundHomecard}>
+								<View
+									style={[
+										HomeStyles.backgroundHomecard,
+										{
+											right:
+												Platform.OS === "android"
+													? screenWidth * 0.1
+													: 30,
+										},
+									]}
+								>
 									<HomeCard />
 								</View>
 								<View
@@ -277,7 +288,7 @@ const HomePage = () => {
 											transform: [{ scale: 0.8 }],
 											right:
 												Platform.OS === "android"
-													? -18
+													? screenWidth * 0.01
 													: -5,
 											zIndex: 0,
 										},

--- a/src/pages/home/HomeStyles.js
+++ b/src/pages/home/HomeStyles.js
@@ -75,7 +75,6 @@ const HomeStyles = StyleSheet.create({
 		position: "absolute",
 		top: 60,
 		bottom: 10,
-		right: Platform.OS === "android" ? 17 : 30,
 		transform: [{ scale: 0.9 }],
 		shadowColor: "#3C454E4A",
 		shadowOffset: { width: 0, height: 3 },

--- a/src/pages/login/FindPasswordPage.js
+++ b/src/pages/login/FindPasswordPage.js
@@ -109,8 +109,9 @@ const FindPasswordPage = () => {
 				<Text style={FindPasswordStyles.textId}>
 					ID (Email Address)
 				</Text>
-				<View style={FindPasswordStyles.textInputId}>
+				<View style={FindPasswordStyles.containerTextInputId}>
 					<TextInput
+						style={FindPasswordStyles.textInputId}
 						placeholder={t("emailPlaceholder")}
 						onChangeText={(text) => handleEmailFormat(text)}
 						value={valueID}
@@ -135,8 +136,9 @@ const FindPasswordPage = () => {
 						>
 							{t("verificationCode")}
 						</Text>
-						<View style={FindPasswordStyles.textInputId}>
+						<View style={FindPasswordStyles.containerTextInputId}>
 							<TextInput
+								style={FindPasswordStyles.textInputId}
 								onChangeText={(text) =>
 									setVerificationCode(text)
 								}

--- a/src/pages/login/FindPasswordStyles.js
+++ b/src/pages/login/FindPasswordStyles.js
@@ -27,21 +27,18 @@ const FindPasswordStyles = StyleSheet.create({
 		marginTop: 120,
 		marginLeft: 24,
 	},
+	containerTextInputId: {
+		marginHorizontal: 24,
+	},
 	textInputId: {
-		...Platform.select({
-			ios: {
-				padding: 12,
-			},
-			android: {
-				paddingHorizontal: 12,
-			},
-		}),
+		width: "100%",
+		height: 44,
+		padding: 12,
 		borderWidth: 1,
 		borderColor: CustomTheme.borderColor,
 		borderRadius: 6,
 		marginTop: 8,
-		marginHorizontal: 25,
-		justifyContent: "center",
+		alignItems: "center",
 	},
 	containerNotMember: {
 		flexDirection: "row",

--- a/src/pages/login/SetPasswordStyles.jsx
+++ b/src/pages/login/SetPasswordStyles.jsx
@@ -52,8 +52,15 @@ const SetPasswordStyles = StyleSheet.create({
 		marginLeft: 3,
 	},
 	applyButton: {
-		position: "absolute",
-		bottom: 126,
+		...Platform.select({
+			ios: {
+				position: "absolute",
+				bottom: 126,
+			},
+			android: {
+				marginTop: 32,
+			},
+		}),
 	},
 });
 


### PR DESCRIPTION
### 개요
안드로이드 관련 ui 수정
<br>

### 수정사항
- 비밀번호 재설정 페이지에서 입력창 클릭 시 버튼 위치 및 입력창 크기 불일치 문제 해결
- 커넥트 섹션 프로필 버튼 영역, 필터 검색 바텀 시트 하단, 가이드 페이지 관련 조정
- 홈 카드 아래 반투명 카드 위치 조정

자세한 사항은 커밋 확인 부탁드립니다!
<br>

### 테스트 화면
**비밀번호 재설정 페이지에서 입력창 클릭 시 버튼 위치 및 입력창 크기 불일치 문제 해결**

<img width="40%" src="https://github.com/user-attachments/assets/138646eb-7160-477d-9263-016b2e25b1d3"/>
<img width="40%" src="https://github.com/user-attachments/assets/3c387561-5c66-4e7b-9610-802908f141d0"/>

<br><br>

**커넥트 섹션 프로필 버튼 영역, 필터 검색 바텀 시트 하단, 가이드 페이지 관련 조정**
본래 디자인에서는 필터 검색 하단에 여백이 있지만, 안드로이드는 화면 내부 하단바 때문에 어색하게 보여 여백을 없앴습니다..!

<img width="40%" src="https://github.com/user-attachments/assets/aa2ca402-1131-46d0-9a89-f64c610f7e37"/>
<img width="40%" src="https://github.com/user-attachments/assets/c5f2bb3f-2f24-493e-aceb-05a32559a0ce"/>
<img width="40%" src="https://github.com/user-attachments/assets/ed6a2903-ea7c-4833-a404-0624aad9a9b9"/>

<br><br>

**홈 카드 아래 반투명 카드 위치 조정**

<img width="40%" src="https://github.com/user-attachments/assets/6fa5bab9-2628-4ca4-b611-e556be416f81"/>


<br><br>

