### PR TITLE
hotfix/projectId-depreceted-deploy-version-1: 배포 전용 projectId는 Constants가 아닌 Updates.manifest를 통해 받아옴

### DIFF
--- a/src/pages/login/LoginPage.js
+++ b/src/pages/login/LoginPage.js
@@ -19,6 +19,7 @@ import { getLocales } from "expo-localization";
 
 import { CustomTheme } from "@styles/CustomTheme";
 import Constants from "expo-constants";
+import * as Updates from "expo-updates";
 import LoginStyles from "@pages/login/LoginStyles";
 import { useAuth } from "src/states/AuthContext";
 import {
@@ -80,7 +81,10 @@ const LoginPage = () => {
 		try {
 			const loginResponse = await login(emailRef.val, valuePW);
 			const { status } = await Notifications.getPermissionsAsync();
-			const projectId = Constants.expoConfig.extra.eas.projectId;
+			const projectId =
+				Constants.expoConfig?.extra?.eas?.projectId ||
+				Updates.manifest?.extra?.eas?.projectId ||
+				null;
 
 			let token = "undefined";
 


### PR DESCRIPTION
### 개요
TestFlight버전에서 테스트해본 후 dev에도 머지해 알림 문제 해결 마무리 예정