### PR TITLE
hotfix/notification-absent-aps-environment-1: aps-environments 명시로 push notifications token 미발급 문제 해결 시도

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -61,6 +61,12 @@ export default {
 					ja: "./locales/ja/InfoPlist.strings",
 				},
 			},
+			entitlements: {
+				"aps-environment":
+					process.env.APP_VARIANT === "staging"
+						? "production"
+						: "development",
+			},
 		},
 		android: {
 			package: getAndroidPackage(),
@@ -84,6 +90,7 @@ export default {
 			url: "https://u.expo.dev/7ec133fc-2004-4a77-9b59-25d22dede97b",
 		},
 		plugins: [
+			"expo-notifications",
 			"expo-secure-store",
 			[
 				"@sentry/react-native/expo",


### PR DESCRIPTION
### Overview

> 문제
- notification 발급 도중의 콘솔 로그 확인 결과 발급 과정에서 
- `푸시 알림 토큰 요청 중 오류 발생: Error: 응용 프로그램을 위한 유효한 ‘aps-environment’ 인타이틀먼트 문자열을 찾을 수 없습니다.` 의 에러가 찍히는 것을 확인

> 해결
- app.config.js에서 명시적으로 aps-environment 추가 및 plugins에 expo-notifications로 해결 시도 

---

> 참고한 이슈
- https://github.com/expo/expo/issues/37101