### PR TITLE
hotfix/update-member-nation-and-languages-1 : 최초 온보딩에서 누락되었던 languages와 nation 문제를 해결한다.

### DIFF
--- a/src/pages/onboarding/OnboardingStep2Page.js
+++ b/src/pages/onboarding/OnboardingStep2Page.js
@@ -29,7 +29,9 @@ const OnboardingStep2Page = ({ goToNext, saveData, stepData }) => {
 
 	const [image, setImage] = useState(stepData[2].image || null);
 	const [bio, setBio] = useState(stepData[2].bio || "");
-	const [nation, setNotion] = useState(stepData[2].selectedCountry || "");
+	const [nation, setNation] = useState(
+		stepData[2].nation || stepData[2].selectedCountry || "",
+	);
 
 	const handleKeyboard = () => {
 		Keyboard.dismiss();
@@ -59,11 +61,13 @@ const OnboardingStep2Page = ({ goToNext, saveData, stepData }) => {
 	};
 
 	useEffect(() => {
-		setNotion(stepData[2].selectedCountry);
+		if (stepData[2].selectedCountry) {
+			setNation(stepData[2].selectedCountry);
+		}
 	}, [stepData[2].selectedCountry]);
 
 	const handleProfileSubmit = () => {
-		saveData(2, { image, bio });
+		saveData(2, { image, bio, nation: nation });
 		goToNext(3);
 	};
 

--- a/src/pages/onboarding/OnboardingStep5Page.js
+++ b/src/pages/onboarding/OnboardingStep5Page.js
@@ -15,17 +15,14 @@ const OnboardingStep5Page = ({ stepData, saveData }) => {
 	const { t } = useTranslation();
 	const navigation = useNavigation();
 
-	const [selectedLanguages, setSelectedLanguages] = useState(
-		stepData[5].selectedLanguages || "",
-	);
 	const languages = t("languages", { returnObjects: true });
+
 	const [isCheckedList, setIsCheckedList] = useState(
 		new Array(languages.length).fill(false),
 	);
 
 	useEffect(() => {
-		if (stepData[5]) {
-			setSelectedLanguages(stepData[5].selectedLanguages);
+		if (stepData[5] && stepData[5].isCheckedList) {
 			setIsCheckedList(stepData[5].isCheckedList);
 		}
 	}, [stepData, languages.length]);
@@ -39,24 +36,42 @@ const OnboardingStep5Page = ({ stepData, saveData }) => {
 	};
 
 	const handleOnboarding = async () => {
-		const tmp = isCheckedList.reduce((selected, isChecked, index) => {
-			if (isChecked) {
-				selected.push(languages[index]);
-			}
-			return selected;
-		}, []);
+		const currentSelectedLanguages = isCheckedList.reduce(
+			(selected, isChecked, index) => {
+				if (isChecked) {
+					selected.push(languages[index]);
+				}
+				return selected;
+			},
+			[],
+		);
 
-		saveData(5, { selectedLanguages: tmp, isCheckedList });
+		saveData(5, {
+			selectedLanguages: currentSelectedLanguages,
+			isCheckedList,
+		});
 
 		const formData = new FormData();
 		formData.append("username", stepData[1].nickname);
 		formData.append("country", stepData[2].nation);
 		formData.append("bio", stepData[2].bio);
+
 		if (stepData[3].selectedMBTI !== t("mbtiNoneOption")) {
 			formData.append("mbti", stepData[3].selectedMBTI);
 		}
-		formData.append("hobbies", stepData[4].selectedHobby);
-		formData.append("languages", selectedLanguages);
+
+		if (Array.isArray(stepData[4].selectedHobby)) {
+			stepData[4].selectedHobby.forEach((hobby) => {
+				formData.append("hobbies", hobby);
+			});
+		} else {
+			formData.append("hobbies", stepData[4].selectedHobby);
+		}
+
+		currentSelectedLanguages.forEach((lang) => {
+			formData.append("languages", lang);
+		});
+
 		const memberId = await SecureStore.getItemAsync("memberId");
 
 		if (stepData[2].image) {
@@ -69,9 +84,8 @@ const OnboardingStep5Page = ({ stepData, saveData }) => {
 		}
 
 		try {
-			navigation.replace("CompleteProfilePage");
 			await updateMyProfile(formData);
-			console.log(formData);
+			navigation.replace("CompleteProfilePage");
 		} catch (error) {
 			Sentry.captureException(error);
 			console.error(


### PR DESCRIPTION
### Overview

[버그/기존] 온보딩 시
- 국가 코드 입력해도 undefined로 백엔드로 넘어옴
- 세팅 언어 입력해도 빈배열로 백엔드로 넘어옴
*설정 수정 시에는 제대로 백엔드로 들어옴

[해결]
- 온보딩 값 가운데 제대로 국가코드와 세팅언어 DB에 저장되도록 

---
> 온보딩 Step2 (nation 누락)
- setNotion 오타 수정, handleProfileSubmit에서 데이터 누락 문제 수정

> 온보딩 Step5 (lanauges누락)
- React의 비동기적 상태 업데이트로 인해 서버 전송 시 이전 데이터가 포함되던 로직을 로컬 변수 직접 참조 방식으로 변경하여 해결

---
성공화면
<img width="378" height="704" alt="Screenshot 2026-01-18 at 12 50 23 PM" src="https://github.com/user-attachments/assets/c890a836-ff72-408c-88c4-6467d1596898" />


Hotfix로 바로 dev/staging 머지하겠습니다! 참고부탁드릴게요!