### PR TITLE
[staging 반영완료 -> sync작업] hotfix/notification-chatroom-false-navigation-1: 잘못된 형태로 넘겨주었던 알림 navigation fix

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -318,9 +318,13 @@ function AppContent() {
 			} else if (type === "REQUEST") {
 				navigation.navigate("ConnectListPage", { screen: "그룹" });
 			} else if (type === "CHATROOM" && chatroomInfo) {
-				navigation.navigate("ChatRoomPage", chatroomInfo);
+				navigation.navigate("ChatRoomPage", {
+					chatroomInfo: chatroomInfo,
+				});
 			} else if (type === "SMALLTALK" && chatroomInfo) {
-				navigation.navigate("ChatRoomPage", chatroomInfo);
+				navigation.navigate("ChatRoomPage", {
+					chatroomInfo: chatroomInfo,
+				});
 			}
 		};
 


### PR DESCRIPTION
알림 navigation할 때 해당하는 채팅방 렌더링 할 때 앱충돌하는 에러 response 형식에 맞추는 것으로 해결했습니다! 참고 부탁드려요!
@nnyouung 