### PR TITLE
feat/reset-smalltalk-noti-cnt-when-clicked-1: 스몰톡 관련 푸시알림/앱 내 알림 클릭 시 네비게이션된 후 알림 count를 초기화하는 api를 호출한다.

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -23,7 +23,7 @@ import { useNavigation } from "@react-navigation/native";
 import i18n from "src/i18n.js";
 import { PostModifyProvider } from "src/states/PostModifyContext";
 import { AuthProvider, useAuth } from "src/states/AuthContext";
-import { getMyProfile } from "config/api";
+import { getMyProfile, resetSmallTalkNotiCnt } from "config/api";
 import { WebSocketProvider } from "./src/context/WebSocketContext";
 import { MatchQueueProvider } from "context/MatchQueueContext";
 import { syncLanguageWithServer } from "src/util/syncLanguageWithServer";
@@ -302,7 +302,7 @@ function AppContent() {
 	}, []);
 
 	useEffect(() => {
-		const handleNotificationResponse = (response) => {
+		const handleNotificationResponse = async (response) => {
 			const { type, typeId, chatroomInfo } =
 				response.notification.request.content.data;
 
@@ -325,6 +325,11 @@ function AppContent() {
 				navigation.navigate("ChatRoomPage", {
 					chatroomInfo: chatroomInfo,
 				});
+				try {
+					await resetSmallTalkNotiCnt(chatroomInfo.id);
+				} catch (error) {
+					console.error("알림 카운트 초기화 실패:", error);
+				}
 			}
 		};
 

--- a/src/components/notification/NotificationCard.js
+++ b/src/components/notification/NotificationCard.js
@@ -6,7 +6,11 @@ import { CustomTheme } from "@styles/CustomTheme";
 
 import IconAddFriend24 from "@components/Icon24/IconAddFriend24";
 import IconHeart24 from "@components/Icon24/IconHeart24";
-import { getProfileById, getChatroomById } from "config/api";
+import {
+	getProfileById,
+	getChatroomById,
+	resetSmallTalkNotiCnt,
+} from "config/api";
 import { useNavigation } from "@react-navigation/native";
 import ModalKebabNotFoundMember from "@components/member/ModalKebabNotFoundMember";
 import IconChat24 from "@components/Icon24/IconChat24";
@@ -75,10 +79,18 @@ const NotificationCard = ({
 		} else if (type === "POST") {
 			navigation.navigate("PostPage", { postId: typeId });
 		} else if (type == "SMALLTALK") {
-			const response = await getChatroomById(typeId);
-			navigation.navigate("ChatRoomPage", {
-				chatroomInfo: response.data,
-			});
+			try {
+				const response = await getChatroomById(typeId);
+				const chatroomData = response.data;
+
+				navigation.navigate("ChatRoomPage", {
+					chatroomInfo: chatroomData,
+				});
+
+				await resetSmallTalkNotiCnt(chatroomData.id);
+			} catch (error) {
+				console.error("SMALLTALK 처리 중 오류:", error);
+			}
 		} else {
 			return;
 		}

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -671,3 +671,7 @@ export const chatSmallTalk = (chatroomId) => {
 		},
 	});
 };
+
+export const resetSmallTalkNotiCnt = (chatroomId) => {
+	return api.patch(`/chatrooms/${chatroomId}/reset/small-talk`);
+};

--- a/src/pages/home/NotificationPage.js
+++ b/src/pages/home/NotificationPage.js
@@ -33,7 +33,7 @@ const NotificationPage = () => {
 			setNotificationData(filteredData.reverse());
 			await SecureStore.setItemAsync(
 				"readNotificationCount",
-				response.data.length.toString(),
+				filteredData.length.toString(),
 			);
 		} catch (error) {
 			console.error(


### PR DESCRIPTION
#### Overview

- PATCH `chatrooms/36/reset/small-talk` 요청으로 스몰톡 알림 선택시에 알림 카운트 초기화하는 동작을 프론트에서 실행한다.
- 기존에 앱 내 알림 갯수에 채팅알림 갯수도 함께 표시가 되었는데 홈에서 알림 아이콘을 클릭하여 보여지는 페이지에서는 채팅 알림은 제외되어서 보여집니다..! 
- 해당 흐름이 어색하다 판단해 채팅알림 갯수는 함께 표시되지 않게 수정을 했는데 검토 후 자유롭게 수정 후 머지 부탁드립니다..! @nnyouung 

---
#### Error Report
- 현재 채팅방 리스트에서는 정상적으로 nickname과 프로필 이미지가 보이나
<img width="563" height="1218" alt="image" src="https://github.com/user-attachments/assets/35d52dfd-b6c0-4493-99fc-2dbe0a542b3a" />


- 채팅방 안으로 들어가면 채팅방 상대방의 nickname이 아닌 본인의 nickname과 본인의 프로필 이미지로 보이는 에러가 존재합니다 예전 QC부터 발생했던 문제인데 급한 에러 먼저 해결하느라 뒤늦게 보고합니다ㅠ! 확인 부탁드립니다..!
<img width="563" height="1218" alt="IMG_9872" src="https://github.com/user-attachments/assets/056e23c3-5837-4069-8dd2-c0eff98bad03" />

