### PR TITLE
feat/send-locale-when-email-code-send -1: 언어별 안내 이메일 인증번호 코드 안내 메일 전송을 위해 인증코드 발송 시에 기기언어도 함께 전송한다.

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -107,9 +107,10 @@ export const getGroupByGroupId = (groupId) => {
 	return api.get(`/chatrooms/${groupId}`);
 };
 
-export const createVerificationCode = (email) => {
+export const createVerificationCode = (email, countryCode) => {
 	return api.post("/members/email", {
 		email,
+		countryCode,
 	});
 };
 

--- a/src/pages/login/SignUpStep2Page.js
+++ b/src/pages/login/SignUpStep2Page.js
@@ -6,6 +6,7 @@ import {
 	Keyboard,
 	TouchableOpacity,
 } from "react-native";
+import { getLocales } from "expo-localization";
 import { useTranslation } from "react-i18next";
 import TextInput from "@components/common/TextInput";
 
@@ -17,6 +18,10 @@ import InfoCircle from "@components/common/InfoCircle";
 import { createVerificationCode, getVerificationCode } from "config/api";
 
 const SignUpStep2Page = ({ saveData, goToNext, stepData }) => {
+	const getDeviceLang = () => {
+		const lang = getLocales()?.[0]?.languageCode?.toLowerCase();
+		return ["ko", "en", "ja", "zh", "es"].includes(lang) ? lang : "en";
+	};
 	const { t } = useTranslation();
 
 	const [valueVerificationCode, onChangeVerificationCode] = useState(
@@ -51,7 +56,7 @@ const SignUpStep2Page = ({ saveData, goToNext, stepData }) => {
 	const fetchCreateVerificationCode = async () => {
 		setTimeLeft(3 * 60);
 		try {
-			await createVerificationCode(stepData[1]);
+			await createVerificationCode(stepData[1], getDeviceLang());
 		} catch (error) {
 			console.error(
 				"회원가입 인증번호 전송 실패:",


### PR DESCRIPTION
이메일 인증번호를 보내는 api의 body에 앱으로 부터 받은 기기언어를 함께 넣어줘 전송하도록 수정해두었습니다!
(현재는 이메일 인증 안내 메일이 한국어로만 나가고 있어 언어에 따라 보여줘야 한다고 판단해서요..!)

간단한 수정사항이라 staging 브랜치까지 머지하도록 하겠습니다!
참고 부탁드려요!

@nnyouung 